### PR TITLE
Fixed missed return ArcBallCamera '=' operator

### DIFF
--- a/Objects/ArcBallCamera.h
+++ b/Objects/ArcBallCamera.h
@@ -41,6 +41,7 @@ namespace ed
 			this->m_yaw = arc.m_yaw;
 			this->m_pitch = arc.m_pitch;
 			this->m_roll = arc.m_roll;
+			return *this;
 		}
 
 	private:


### PR DESCRIPTION
Fixed missed return ArcBallCamera '=' operator.
Details:
inline ArcBallCamera& operator=(const ArcBallCamera& arc)  - it should return ArcBallCamera& value so I've added 'return *this;' to fix it. 
