### PR TITLE
Memory leak fix

### DIFF
--- a/UI/CreateItemUI.cpp
+++ b/UI/CreateItemUI.cpp
@@ -652,10 +652,33 @@ namespace ed
 	void CreateItemUI::SetType(PipelineItem::ItemType type)
 	{
 		m_errorOccured = false;
+		
+		//TODO: make it type-safe.
+		if (m_item.Data != nullptr) {
+			switch (m_item.Type) {
+				case PipelineItem::ItemType::Geometry:
+					delete (pipe::GeometryItem*)m_item.Data;
+					break;
+				case PipelineItem::ItemType::ShaderPass:
+					delete (pipe::ShaderPass*)m_item.Data;
+					break;
+				case PipelineItem::ItemType::RenderState:
+					delete (pipe::RenderState *)m_item.Data;
+					break;
+				case PipelineItem::ItemType::Model:
+					delete (pipe::Model *)m_item.Data;
+					break;
+				case PipelineItem::ItemType::ComputePass:
+					delete (pipe::ComputePass *)m_item.Data;
+					break;
+				case PipelineItem::ItemType::AudioPass:
+					delete (pipe::AudioPass *)m_item.Data;
+					break;
+			}
+			m_item.Data = nullptr;
+		}
+		
 		m_item.Type = type;
-
-		if (m_item.Data != nullptr)
-			delete m_item.Data;
 
 		if (m_item.Type == PipelineItem::ItemType::Geometry) {
 			Logger::Get().Log("Opening a CreateItemUI for creating Geometry object...");


### PR DESCRIPTION
```
		if (m_item.Data != nullptr)
			delete m_item.Data;
```
m_item.Data:
https://github.com/dfranx/SHADERed/blob/24ba95faebfde61581a08792b82f5ad2cb13d69f/Objects/PipelineItem.h#L45

it leads to mem leak as 'delete' operator can't delete 'void*' proper. (not type information -> not size data, and no information about destructor, ... )
https://github.com/dfranx/SHADERed/blob/24ba95faebfde61581a08792b82f5ad2cb13d69f/Objects/PipelineItem.h#L45
i.e. destructors of internal fields (ex https://github.com/dfranx/SHADERed/blob/24ba95faebfde61581a08792b82f5ad2cb13d69f/Objects/PipelineItem.h#L78)  won't be executed.