### PR TITLE
[TRIVIAL] Mem-leak fix

### DIFF
--- a/UI/UIView.h
+++ b/UI/UIView.h
@@ -9,7 +9,8 @@ namespace ed
 	{
 	public:
 		UIView(GUIManager* ui, ed::InterfaceManager* objects, const std::string& name = "", bool visible = true) : m_ui(ui), m_data(objects), Visible(visible), Name(name) {}
-
+		virtual ~UIView() {}
+		
 		virtual void OnEvent(const SDL_Event& e) = 0;
 		virtual void Update(float delta) = 0;
 


### PR DESCRIPTION
Base class should have a virtual destructor otherwise ```delete (UIView*) some_ptr;``` won't be able to call a derived destructor (even a default one).