### PR TITLE
Add XDG desktop and AppData files for Linux integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ else()
 		"${SOURCES}"
 		libs/nativefiledialog/nfd_gtk.c
 	)
-	
+
 	# link gtk on linux
 	find_package(PkgConfig REQUIRED)
 	pkg_check_modules(GTK REQUIRED gtk+-3.0)
@@ -107,7 +107,7 @@ else()
 	add_definitions(${GTK_CFLAGS})
 endif()
 
-# cmake toolchain 
+# cmake toolchain
 if(CMAKE_TOOLCHAIN_FILE)
     include(${CMAKE_TOOLCHAIN_FILE})
 endif(CMAKE_TOOLCHAIN_FILE)
@@ -184,3 +184,8 @@ set(RESOURCE_INST_DESTINATION "share/shadered")
 install(PROGRAMS bin/SHADERed DESTINATION "${BINARY_INST_DESTINATION}" RENAME shadered)
 install(DIRECTORY bin/data bin/templates bin/themes DESTINATION "${RESOURCE_INST_DESTINATION}")
 
+if (UNIX AND NOT APPLE)
+	# install XDG desktop file and icon on Linux/BSD
+	install(FILES Misc/Linux/io.github.dfranx.SHADERed.desktop DESTINATION "share/applications" RENAME shadered.desktop)
+	install(FILES bin/icon.png DESTINATION "share/icons/hicolor/64x64/apps" RENAME shadered.png)
+endif()

--- a/Misc/Linux/io.github.dfranx.SHADERed.appdata.xml
+++ b/Misc/Linux/io.github.dfranx.SHADERed.appdata.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2019 dfranx -->
+<component type="desktop">
+  <id>io.github.dfranx.SHADERed.desktop</id>
+  <name>SHADERed</name>
+  <summary>Tool for creating and testing HLSL and GLSL shaders</summary>
+  <description>
+    <p>
+      SHADERed is a lightweight tool for creating and testing HLSL and GLSL
+      shaders. It is easy to use, open source, cross-platform (runs on Windows
+      &amp; Linux - HLSL shaders work on both OS) and frequently updated with
+      new features.
+    </p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer_name>dfranx</developer_name>
+  <url type="homepage">https://github.com/dfranx/SHADERed</url>
+  <url type="help">https://github.com/dfranx/SHADERed/blob/master/TUTORIAL.md</url>
+  <url type="bugtracker">https://github.com/dfranx/SHADERed/issues</url>
+  <url type="donation">https://www.patreon.com/dfranx</url>
+  <screenshots>
+    <screenshot type="default" width="1745" height="979">
+      <image type="source">https://raw.githubusercontent.com/dfranx/SHADERed/master/Screenshots/IMG2.png</image>
+      <caption>Editing an HLSL shader</caption>
+    </screenshot>
+    <screenshot type="default" width="1919" height="1036">
+      <image type="source">https://raw.githubusercontent.com/dfranx/SHADERed/master/Screenshots/screen1.jpg</image>
+      <caption>Editing a GLSL shader with live preview</caption>
+    </screenshot>
+    <screenshot type="default" width="1284" height="911">
+      <image type="source">https://user-images.githubusercontent.com/3957610/64245795-e54b0680-cf0b-11e9-8799-ea7ace785190.png</image>
+      <caption>Testing a directional shadow shader</caption>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="1.2.4" date="2019-10-31"/>
+  </releases>
+  <update_contact>hugo.locurcio@hugo.pro</update_contact>
+</component>

--- a/Misc/Linux/io.github.dfranx.SHADERed.desktop
+++ b/Misc/Linux/io.github.dfranx.SHADERed.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=SHADERed
+GenericName=Shader editor
+GenericName[fr]=Éditeur de shaders
+Comment=Tool for creating and testing HLSL and GLSL shaders
+Comment[fr]=Outil pour créer et tester des shaders HLSL et GLSL
+Exec=shadered
+Icon=shadered
+Terminal=false
+Type=Application
+Categories=Development;


### PR DESCRIPTION
This also installs those files in CMake to expose SHADERed to the application launcher once installed.