### PR TITLE
Added Support for Out-of-Source Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ vsproject32
 test
 CMakeCache.txt
 Makefile
+
+# Ignore out-of-source build directory.
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(SHADERed)
 
-set(CMAKE_MODULE_PATH "./cmake")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ./bin)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
 
 # source code
 set(SOURCES

--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ cmake -DUSE_FINDSFML=ON .
 make
 ```
 
+If you would like to perform an out-of-source build, do the following:
+```
+mkdir build
+cd build
+cmake .. # or, if SFML 2.5 is not installed, cmake -DUSE_FINDSFML=ON ..
+make
+```
+
 Run:
 ```
 ./bin/SHADERed


### PR DESCRIPTION
The default behaviour when compiling with CMake is an in-source build, which mixes build artifacts with the source. I don't find this as a good way to compile the project. As such, I added support for out-of-source builds, which places the build artifacts in a separate. However, I still kept the binary output to the `bin/` directory. The default behaviour of performing in-source builds still works, as per my limited testing.

In conjunction with this support for out-of-source builds, I also updated the docs, primarily the `README.md` file.