### PR TITLE
Fix build configuration for macOS 10.14+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
+set(CMAKE_CXX_STANDARD 17)
 project(SHADERed)
 
 # ShaderDebugger
@@ -155,6 +156,9 @@ add_subdirectory(libs/glslang)
 
 # Native macOS frameworks
 if (APPLE)
+	# Link Homebrew library path for Mojave and up
+	# See: https://stackoverflow.com/questions/54068035/linking-not-working-in-homebrews-cmake-since-mojave
+	link_directories(/usr/local/lib)
 	set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework AppKit -framework AudioToolbox -framework AudioUnit -framework Carbon -framework Cocoa -framework CoreAudio -framework CoreVideo -framework ForceFeedback -framework IOKit -framework OpenGL -framework CoreServices -framework Security")
 	set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -framework AppKit -framework AudioToolbox -framework AudioUnit -framework Carbon -framework Cocoa -framework CoreAudio -framework CoreVideo -framework ForceFeedback -framework IOKit -framework OpenGL -framework CoreServices -framework Security")
 endif()

--- a/README.md
+++ b/README.md
@@ -144,24 +144,29 @@ Run:
 
 Install all the libraries that are needed:
 
-```shell script
+```sh
 brew install sdl2 sfml glew glm assimp
 ```
 
 Build:
 
-```shell script
+```sh
 mkdir build
 cd build
 cmake ../
 make -j8
 ```
 
+> **Note:** If you're building on a macOS version prior to 10.15 (Catalina) you may need to update Xcode and create a symlink for the SDK:
+> 
+> ```
+> ln -s "$(xcrun --sdk macosx --show-sdk-path)" "$(xcrun --sdk macosx --show-sdk-platform-path)/Developer/SDKs/MacOSX10.15.sdk"
+> ```
+
 Run:
 ```
 ./bin/SHADERed
 ```
-
 
 ### Windows
 1. Install SDL2, SFML, GLEW, GLM, ASSIMP through your favourite package manager (I recommend vcpkg)


### PR DESCRIPTION
This PR solves some issues when building the project on macOS. Following the instructions in README didn't work for at least versions below 10.15 (Catalina).

The CMake configuration now sets `CMAKE_CXX_STANDARD` to `17` to support C++17 features. This was previously ignored by CMake and/or compilers and would result in errors with unsupported features in previous C++ versions.

Due to changes in Mojave which [broke linking Homebrew libraries](https://stackoverflow.com/questions/54068035/linking-not-working-in-homebrews-cmake-since-mojave), the CMake configuration will now link the `/usr/local/lib` directory to make it possible to link Homebrew-installed libraries for macOS builds.

There's also now some extra information added to help solve issues with SDK target no being correct. This is something I haven't been able to solve by configuration:

- Setting the environment variables ([`MACOSX_DEPLOYMENT_TARGET`](https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html) and [`SDKROOT`](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html?highlight=sdkroot)) didn't work.
- Setting variables ([`CMAKE_OSX_DEPLOYMENT_TARGET`](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) and [`CMAKE_OSX_SYSROOT`](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html)) in CMake didn't work.
- Neither did passing the CMake variables as D flags.

The last resort I could come up with was to simply symlink the installed SDK to the project's target SDK.