### PR TITLE
Fix release order in AppStream metadata

### DIFF
--- a/Misc/Linux/org.shadered.SHADERed.appdata.xml
+++ b/Misc/Linux/org.shadered.SHADERed.appdata.xml
@@ -27,8 +27,8 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.3" date="2020-02-25"/>
     <release version="1.3.2" date="2020-04-03"/>
+    <release version="1.3" date="2020-02-25"/>
   </releases>
   <update_contact>hugo.locurcio@hugo.pro</update_contact>
 </component>


### PR DESCRIPTION
The AppStream specification requires recent releases to be put first (instead of last).