### PR TITLE
glutils: fix glsl error parsing for amd

### DIFF
--- a/src/SHADERed/Engine/GLUtils.cpp
+++ b/src/SHADERed/Engine/GLUtils.cpp
@@ -197,9 +197,30 @@ namespace ed {
 				if (line.find("error") != std::string::npos) {
 					size_t firstPar = line.find_first_of('(');
 					size_t lastPar = line.find_first_of(')', firstPar);
-					int lineNr = std::stoi(line.substr(firstPar + 1, lastPar - (firstPar + 1))) - lineBias;
-					std::string msg = line.substr(line.find_first_of(':') + 2);
-					ret.push_back(MessageStack::Message(MessageStack::Type::Error, owner, msg, lineNr, shader));
+					size_t firstD = line.find_first_of(':');
+
+					if (firstPar == std::string::npos || lastPar == std::string::npos || firstD == std::string::npos)
+						continue;
+
+					if (line[firstPar + 1] == '#') {
+						// AMD error
+						size_t secondD = line.find_first_of(':', firstD + 1);
+						size_t thirdD = line.find_first_of(':', secondD + 1);
+
+						if (secondD == std::string::npos || thirdD == std::string::npos)
+							continue;
+
+						int lineNr = std::stoi(line.substr(secondD + 1, thirdD - (secondD + 1)));
+						std::string msg = line.substr(thirdD + 2);
+						ret.push_back(MessageStack::Message(MessageStack::Type::Error, owner, msg, lineNr, shader));
+
+					} else {
+						// Nvidia error
+						int lineNr = std::stoi(line.substr(firstPar + 1, lastPar - (firstPar + 1))) - lineBias;
+						std::string msg = line.substr(firstD + 2);
+						ret.push_back(MessageStack::Message(MessageStack::Type::Error, owner, msg, lineNr, shader));
+					}
+
 				}
 			}
 


### PR DESCRIPTION
Related/fixes #73 (i think)

Amd gl outputs errors from `glgetShaderInfoLog` in a different format than what the previous implementation expected, which would cause a crash calling stoi on an invalid number string

Example amd output:
```
Vertex shader failed to compile with the following errors:
ERROR: 0:10: error(#132) Syntax error: "rawr" parse error
ERROR: error(#273) 1 compilation errors.  No code generated
```
This fixes crash to parse the second line correctly, the last line will be ignored, but im not sure if theres any value in it, this also may want to be tested on nvidia, but the code path should be the same as before in that case