### PR TITLE
Update AppStream metadata for 1.3.5

### DIFF
--- a/Misc/Linux/org.shadered.SHADERed.appdata.xml
+++ b/Misc/Linux/org.shadered.SHADERed.appdata.xml
@@ -27,8 +27,12 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.3.5" date="2020-07-12"/>
+    <release version="1.3.4" date="2020-05-17"/>
+    <release version="1.3.3" date="2020-04-17"/>
     <release version="1.3.2" date="2020-04-03"/>
-    <release version="1.3" date="2020-02-25"/>
+    <release version="1.3.1" date="2020-03-18"/>
+    <release version="1.3" date="2020-02-25"/> 
   </releases>
   <update_contact>hugo.locurcio@hugo.pro</update_contact>
 </component>


### PR DESCRIPTION
This also adds releases that were previously missing in the release log.