### PR TITLE
Fix always adding the project extension when saving

### DIFF
--- a/src/SHADERed/GUIManager.cpp
+++ b/src/SHADERed/GUIManager.cpp
@@ -35,6 +35,7 @@
 #include <imgui/examples/imgui_impl_opengl3.h>
 #include <imgui/examples/imgui_impl_sdl.h>
 #include <imgui/imgui.h>
+#include <boost/algorithm/string/predicate.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -2406,6 +2407,10 @@ namespace ed {
 	{
 		std::string file;
 		bool success = UIHelper::GetSaveFileDialog(file, "*.sprj");
+
+		if (!boost::algorithm::ends_with(file, ".sprj")) {
+			file += ".sprj";
+		}
 
 		if (success) {
 			m_data->Parser.SaveAs(file, true);


### PR DESCRIPTION
In my setup (Arch Linux + GNOME) the project extension isn't added
automatically. Thus, when you don't manually add the extension in the
saving dialog, you can't open the project (because the files are
filtered by the .sprj extension)


Side note: Could you please run `clang-format` on all files :)?