### PR TITLE
Index buffer support for Vertex Buffers

### DIFF
--- a/src/SHADERed/Objects/PipelineItem.h
+++ b/src/SHADERed/Objects/PipelineItem.h
@@ -182,10 +182,12 @@ namespace ed {
 				Scale = glm::vec3(1, 1, 1);
 				Topology = GL_TRIANGLES;
 				Buffer = 0;
+				IndexBuffer = 0;
 				VAO = 0;
 			}
 
 			void* Buffer;
+			void* IndexBuffer;
 			GLuint VAO;
 
 			unsigned int Topology;

--- a/src/SHADERed/Objects/ProjectParser.cpp
+++ b/src/SHADERed/Objects/ProjectParser.cpp
@@ -1261,6 +1261,7 @@ namespace ed {
 				pipe::VertexBuffer* tData = reinterpret_cast<pipe::VertexBuffer*>(item->Data);
 
 				itemNode.append_child("buffer").text().set(m_objects->GetBufferNameByID(((ed::BufferObject*)tData->Buffer)->ID).c_str());
+				itemNode.append_child("indexbuffer").text().set(m_objects->GetBufferNameByID(((ed::BufferObject*)tData->IndexBuffer)->ID).c_str());
 				if (tData->Scale.x != 1.0f)
 					itemNode.append_child("scaleX").text().set(tData->Scale.x);
 				if (tData->Scale.y != 1.0f)
@@ -1304,7 +1305,7 @@ namespace ed {
 	void ProjectParser::m_importItems(const char* name, pipe::ShaderPass* data, const pugi::xml_node& node, const std::vector<InputLayoutItem>& inpLayout,
 		std::map<pipe::GeometryItem*, std::pair<std::string, pipe::ShaderPass*>>& geoUBOs,
 		std::map<pipe::Model*, std::pair<std::string, pipe::ShaderPass*>>& modelUBOs,
-		std::map<pipe::VertexBuffer*, std::pair<std::string, pipe::ShaderPass*>>& vbUBOs)
+		std::map<pipe::VertexBuffer*, std::tuple<std::string, std::string, pipe::ShaderPass*>>& vbUBOs)
 	{
 		for (pugi::xml_node itemNode : node.children()) {
 			char itemName[PIPELINE_ITEM_NAME_LENGTH];
@@ -1503,9 +1504,12 @@ namespace ed {
 				pipe::VertexBuffer* vbData = (pipe::VertexBuffer*)itemData;
 
 				vbData->Buffer = 0;
+				vbData->IndexBuffer = 0;
 				vbData->Scale = glm::vec3(1, 1, 1);
 				vbData->Position = glm::vec3(0, 0, 0);
 				vbData->Rotation = glm::vec3(0, 0, 0);
+
+				vbUBOs[vbData] = std::make_tuple("", "", data);
 
 				for (pugi::xml_node attrNode : itemNode.children()) {
 					if (strcmp(attrNode.name(), "scaleX") == 0)
@@ -1527,7 +1531,9 @@ namespace ed {
 					else if (strcmp(attrNode.name(), "z") == 0)
 						vbData->Position.z = attrNode.text().as_float();
 					else if (strcmp(attrNode.name(), "buffer") == 0)
-						vbUBOs[vbData] = std::make_pair(attrNode.text().as_string(), data);
+						std::get<0>(vbUBOs[vbData]) = attrNode.text().as_string();
+					else if (strcmp(attrNode.name(), "indexbuffer") == 0)
+						std::get<1>(vbUBOs[vbData]) = attrNode.text().as_string();
 					else if (strcmp(attrNode.name(), "topology") == 0) {
 						for (int k = 0; k < HARRAYSIZE(TOPOLOGY_ITEM_NAMES); k++)
 							if (strcmp(attrNode.text().as_string(), TOPOLOGY_ITEM_NAMES[k]) == 0)
@@ -2201,7 +2207,7 @@ namespace ed {
 		std::map<pipe::ShaderPass*, std::vector<std::string>> fbos;
 		std::map<pipe::GeometryItem*, std::pair<std::string, pipe::ShaderPass*>> geoUBOs; // buffers that are bound to pipeline items
 		std::map<pipe::Model*, std::pair<std::string, pipe::ShaderPass*>> modelUBOs;
-		std::map<pipe::VertexBuffer*, std::pair<std::string, pipe::ShaderPass*>> vbUBOs;
+		std::map<pipe::VertexBuffer*, std::tuple<std::string, std::string, pipe::ShaderPass*>> vbUBOs;
 
 		// shader passes
 		for (pugi::xml_node passNode : projectNode.child("pipeline").children("pass")) {
@@ -3073,11 +3079,14 @@ namespace ed {
 			}
 		}
 		for (auto& vb : vbUBOs) {
-			BufferObject* bobj = m_objects->GetBuffer(vb.second.first);
+			BufferObject* bobj = m_objects->GetBuffer(std::get<0>(vb.second));
 			vb.first->Buffer = bobj;
 
 			if (bobj)
 				gl::CreateBufferVAO(vb.first->VAO, bobj->ID, m_objects->ParseBufferFormat(bobj->ViewFormat));
+
+			BufferObject* ibobj = m_objects->GetBuffer(std::get<1>(vb.second));
+			vb.first->IndexBuffer = ibobj;
 		}
 
 		// bind objects

--- a/src/SHADERed/Objects/ProjectParser.h
+++ b/src/SHADERed/Objects/ProjectParser.h
@@ -81,7 +81,7 @@ namespace ed {
 		void m_importItems(const char* owner, pipe::ShaderPass* data, const pugi::xml_node& node, const std::vector<InputLayoutItem>& inpLayout,
 			std::map<pipe::GeometryItem*, std::pair<std::string, pipe::ShaderPass*>>& geoUBOs,
 			std::map<pipe::Model*, std::pair<std::string, pipe::ShaderPass*>>& modelUBOs,
-			std::map<pipe::VertexBuffer*, std::pair<std::string, pipe::ShaderPass*>>& vbUBOs); // TODO: why not just use PipelineItem
+			std::map<pipe::VertexBuffer*, std::tuple<std::string, std::string, pipe::ShaderPass*>>& vbUBOs); // TODO: why not just use PipelineItem
 
 		bool m_modified;
 

--- a/src/SHADERed/Objects/RenderEngine.cpp
+++ b/src/SHADERed/Objects/RenderEngine.cpp
@@ -358,7 +358,21 @@ namespace ed {
 								data->Variables.Bind(item);
 
 								glBindVertexArray(vbData->VAO);
-								glDrawArrays(vbData->Topology, 0, vertCount);
+
+								if(vbData->IndexBuffer)
+								{
+									ed::BufferObject* ibobj = (ed::BufferObject*)vbData->IndexBuffer;
+									auto fmt = m_objects->ParseBufferFormat(ibobj->ViewFormat);
+
+									// Todo: There might be use cases where index buffers are a short or byte. The current view format does not allow expressing that, however
+									if (fmt.size() == 1 && fmt[0] == ShaderVariable::ValueType::Integer1)
+									{
+										glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibobj->ID);
+										glDrawElements(vbData->Topology, ibobj->Size / sizeof(uint32_t), GL_UNSIGNED_INT, nullptr);
+									}
+								}
+								else
+									glDrawArrays(vbData->Topology, 0, vertCount);
 							}
 						}
 					} else if (item->Type == PipelineItem::ItemType::RenderState) {

--- a/src/SHADERed/Objects/RenderEngine.cpp
+++ b/src/SHADERed/Objects/RenderEngine.cpp
@@ -359,19 +359,16 @@ namespace ed {
 
 								glBindVertexArray(vbData->VAO);
 
-								if(vbData->IndexBuffer)
-								{
+								if(vbData->IndexBuffer) {
 									ed::BufferObject* ibobj = (ed::BufferObject*)vbData->IndexBuffer;
 									auto fmt = m_objects->ParseBufferFormat(ibobj->ViewFormat);
 
 									// Todo: There might be use cases where index buffers are a short or byte. The current view format does not allow expressing that, however
-									if (fmt.size() == 1 && fmt[0] == ShaderVariable::ValueType::Integer1)
-									{
+									if(fmt.size() == 1 && fmt[0] == ShaderVariable::ValueType::Integer1) {
 										glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibobj->ID);
 										glDrawElements(vbData->Topology, ibobj->Size / sizeof(uint32_t), GL_UNSIGNED_INT, nullptr);
 									}
-								}
-								else
+								} else
 									glDrawArrays(vbData->Topology, 0, vertCount);
 							}
 						}

--- a/src/SHADERed/UI/PropertyUI.cpp
+++ b/src/SHADERed/UI/PropertyUI.cpp
@@ -971,6 +971,36 @@ namespace ed {
 					ImGui::NextColumn();
 					ImGui::Separator();
 
+					/* buffers */
+					ImGui::Text("Index Buffer:");
+					ImGui::NextColumn();
+
+					ImGui::PushItemWidth(-1);
+					if (ImGui::BeginCombo("##pui_ib_buffer", ((item->IndexBuffer == nullptr) ? "NULL" : (m_data->Objects.GetBufferNameByID(((BufferObject*)item->IndexBuffer)->ID).c_str())))) {
+						// null element
+						if (ImGui::Selectable("NULL", item->IndexBuffer == nullptr)) {
+							item->IndexBuffer = nullptr;
+							m_data->Parser.ModifyProject();
+						}
+
+						for (int i = 0; i < bufList.size(); i++) {
+							if (bufList[i]->Buffer == nullptr)
+								continue;
+
+							ed::BufferObject* buf = bufList[i]->Buffer;
+
+							if (ImGui::Selectable(bufNames[i].c_str(), buf == item->IndexBuffer)) {
+								item->IndexBuffer = buf;
+								m_data->Parser.ModifyProject();
+							}
+						}
+
+						ImGui::EndCombo();
+					}
+					ImGui::PopItemWidth();
+					ImGui::NextColumn();
+					ImGui::Separator();
+
 					/* position */
 					ImGui::Text("Position:");
 					ImGui::NextColumn();


### PR DESCRIPTION
This adds index buffer support for Vertex Buffer objects. I'm using this to prototype some things outside of our game engine, where a compute shader produces a bunch of vertex data and we have a static index buffer for it (that got imported from a file). Although it's not unreasonable to think that generating a index buffer in a compute shader is another use case. Either way, it was something that I felt was missing for my use case.

Also, I realize that this failed the CI check. Unfortunately I have _no_ idea how to parse the output, so I was hoping you could help me with it. The test shows files that I didn't even touch as re-formatted, and there is a ton of noise (I think?) in there that makes it hard to figure out what exactly it would like to have changed.