### PR TITLE
Use the GLVND OpenGL library on Linux by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,8 @@ else()
 endif()
 
 # opengl
+set(OpenGL_GL_PREFERENCE GLVND CACHE STRING "Linux only: if GLVND, use the vendor-neutral GL libraries (default). If LEGACY, use the legacy ones (might be necessary to have working optirun/primusrun)")
+set_property(CACHE OpenGL_GL_PREFERENCE PROPERTY STRINGS GLVND LEGACY)
 find_package(OpenGL REQUIRED)
 
 # glew
@@ -205,7 +207,7 @@ if (NOT WIN32)
 	target_include_directories(SHADERed PRIVATE ${GTK_INCLUDE_DIRS})
 endif()
 
-# link libraries 
+# link libraries
 target_link_libraries(SHADERed ${OPENGL_LIBRARIES} ${GLM_LIBRARY_DIRS} glslang SPIRV SPIRVVM assimp::assimp)
 
 # link SpvGenTwo


### PR DESCRIPTION
This silences a CMake warning about OpenGL when compiling on Linux: 

```
CMake Warning (dev) at /usr/share/cmake/Modules/FindOpenGL.cmake:305 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /usr/lib64/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so
    OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  CMakeLists.txt:131 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

The legacy library can still be specified by passing `-DOpenGL_GL_PREFERENCE=LEGACY` on the CMake command line.

Inspired by https://github.com/dolphin-emu/dolphin/pull/8448.