### PR TITLE
Fix compilation errors in Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ if (NOT WIN32)
 endif()
 
 # link libraries
-target_link_libraries(SHADERed ${OPENGL_LIBRARIES} ${GLM_LIBRARY_DIRS} glslang SPIRV SPIRVVM assimp::assimp)
+target_link_libraries(SHADERed ${OPENGL_LIBRARIES} ${GLM_LIBRARY_DIRS} glslang SPIRV SPIRVVM SPIRV-Tools SPIRV-Headers assimp::assimp)
 
 # link SpvGenTwo
 if (BUILD_IMMEDIATE_MODE)

--- a/src/SHADERed/UI/Debug/VectorWatchUI.cpp
+++ b/src/SHADERed/UI/Debug/VectorWatchUI.cpp
@@ -8,6 +8,9 @@
 
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
+
+#define GLM_ENABLE_EXPERIMENTAL 1
+
 #include <glm/gtx/euler_angles.hpp>
 
 const char* SIMPLE_VECTOR_VS_CODE = R"(


### PR DESCRIPTION
Compiling SHADERed in Linux (specifically, elementaryOS 5.1) with GCC 10 would result in compilation errors when compiling using the following commands:

````
$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DSPVGENTWO_BUILD_DISASSEMBLER=TRUE -DUSE_FINDSFML=ON
$ cmake --build build
````

The errors are missing `include/` directories and a missing definition for an experimental GLM feature. One of the errors is shown below.

![One of the compilation errors.](https://user-images.githubusercontent.com/7175885/103122228-5a6ebc00-46ba-11eb-9c51-7aebe64bb065.png)

This PR fixes those errors.
