### PR TITLE
Fix compilation on OSX Catalina

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ bin/log.txt
 
 # Ignore out-of-source build directory.
 build/
+
+# MacOS
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ endif()
 
 # include directories
 target_include_directories(SHADERed PRIVATE ${SDL2_INCLUDE_DIRS} ${GLM_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIRS} ${ASSIMP_INCLUDE_DIR} ${SFML_INCLUDE_DIR})
-target_include_directories(SHADERed PRIVATE src libs libs/glslang libs/SPIRV-VM/inc)
+target_include_directories(SHADERed PRIVATE src libs libs/glslang libs/SPIRV-VM/inc libs/spirv-headers/include libs/spirv-tools/include)
 if (NOT WIN32)
 	target_include_directories(SHADERed PRIVATE ${GTK_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
This PR fixes compilation on OSX Catalina. The issue was that some include directories were missing from `CMakeLists.txt`