### PR TITLE
Add missing time control buttons to the preview UI

### DIFF
--- a/bin/data/shortcuts.kb
+++ b/bin/data/shortcuts.kb
@@ -65,10 +65,13 @@ Gizmo.Rotation CTRL G R
 Gizmo.Scale CTRL G S
 Preview.Delete Delete
 Preview.Duplicate SHIFT D
+Preview.DecreaseTime CTRL Left
+Preview.DecreaseTimeFast CTRL SHIFT Left
 Preview.IncreaseTime CTRL Right
 Preview.IncreaseTimeFast CTRL SHIFT Right
 Preview.SaveImage CTRL R
 Preview.SelectAll SHIFT A
+Preview.ResetTime Backspace
 Preview.TogglePause Space
 Preview.ToggleStatusbar CTRL SHIFT F3
 Preview.Unselect CTRL SHIFT Delete

--- a/src/SHADERed/UI/PreviewUI.cpp
+++ b/src/SHADERed/UI/PreviewUI.cpp
@@ -139,6 +139,28 @@ namespace ed {
 				m_picks.clear();
 			}
 		});
+		KeyboardShortcuts::Instance().SetCallback("Preview.DecreaseTime", [=]() {
+			if (!m_data->Renderer.IsPaused())
+				return;
+
+			float deltaTime = SystemVariableManager::Instance().GetTimeDelta();
+
+			SystemVariableManager::Instance().AdvanceTimer(-deltaTime);
+			SystemVariableManager::Instance().SetFrameIndex(SystemVariableManager::Instance().GetFrameIndex() - 1);
+
+			m_data->Renderer.Render(m_imgSize.x, m_imgSize.y);
+		});
+		KeyboardShortcuts::Instance().SetCallback("Preview.DecreaseTimeFast", [=]() {
+			if (!m_data->Renderer.IsPaused())
+				return;
+
+			float deltaTime = SystemVariableManager::Instance().GetTimeDelta();
+
+			SystemVariableManager::Instance().AdvanceTimer(-0.1f);
+			SystemVariableManager::Instance().SetFrameIndex(SystemVariableManager::Instance().GetFrameIndex() - 0.1f / deltaTime);
+
+			m_data->Renderer.Render(m_imgSize.x, m_imgSize.y);
+		});
 		KeyboardShortcuts::Instance().SetCallback("Preview.IncreaseTime", [=]() {
 			if (!m_data->Renderer.IsPaused())
 				return;
@@ -160,6 +182,12 @@ namespace ed {
 			SystemVariableManager::Instance().SetFrameIndex(SystemVariableManager::Instance().GetFrameIndex() + 0.1f / deltaTime); // add estimated number of frames
 
 			m_data->Renderer.Render(m_imgSize.x, m_imgSize.y);
+		});
+		KeyboardShortcuts::Instance().SetCallback("Preview.ResetTime", [=]() {
+			SystemVariableManager::Instance().Reset();
+
+			if (m_data->Renderer.IsPaused())
+				m_data->Renderer.Render(m_imgSize.x, m_imgSize.y);
 		});
 		KeyboardShortcuts::Instance().SetCallback("Preview.TogglePause", [=]() {
 			m_pause();
@@ -1092,16 +1120,40 @@ namespace ed {
 			ImGui::SameLine();
 		}
 
-		float pauseStartX = (width - ((ICON_BUTTON_WIDTH * 2) + (BUTTON_INDENT * 1))) / 2;
-		if (ImGui::GetCursorPosX() >= pauseStartX - 100)
+		float controlsStartX = (width - ((ICON_BUTTON_WIDTH * 4) + (BUTTON_INDENT * 3))) / 2;
+		if (ImGui::GetCursorPosX() >= controlsStartX - 100)
 			ImGui::SameLine();
 		else
-			ImGui::SetCursorPosX(pauseStartX);
+			ImGui::SetCursorPosX(controlsStartX);
 
+		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
+
+		if (ImGui::Button(UI_ICON_PRESS, ImVec2(ICON_BUTTON_WIDTH, BUTTON_SIZE)) && m_data->Renderer.IsPaused()) {
+			float deltaTime = SystemVariableManager::Instance().GetTimeDelta();
+
+			if (ImGui::GetIO().KeyCtrl) {
+				SystemVariableManager::Instance().AdvanceTimer(-deltaTime);
+				SystemVariableManager::Instance().SetFrameIndex(SystemVariableManager::Instance().GetFrameIndex() - 1);
+			} else {
+				SystemVariableManager::Instance().AdvanceTimer(-0.1f);
+				SystemVariableManager::Instance().SetFrameIndex(SystemVariableManager::Instance().GetFrameIndex() - 0.1f / deltaTime);
+			}
+
+			m_data->Renderer.Render(m_imgSize.x, m_imgSize.y);
+		}
+
+		/* RESET TIME BUTTON */
+		ImGui::SameLine();
+		if (ImGui::Button(UI_ICON_UNDO, ImVec2(ICON_BUTTON_WIDTH, BUTTON_SIZE))) {
+			SystemVariableManager::Instance().Reset();
+
+			if (m_data->Renderer.IsPaused())
+				m_data->Renderer.Render(m_imgSize.x, m_imgSize.y);
+		}
 
 		/* PAUSE BUTTON */
-		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-		if (ImGui::Button(m_data->Renderer.IsPaused() ? UI_ICON_PLAY : UI_ICON_PAUSE, ImVec2(ICON_BUTTON_WIDTH, BUTTON_SIZE))) 
+		ImGui::SameLine();
+		if (ImGui::Button(m_data->Renderer.IsPaused() ? UI_ICON_PLAY : UI_ICON_PAUSE, ImVec2(ICON_BUTTON_WIDTH, BUTTON_SIZE)))
 			m_pause();
 
 		ImGui::SameLine(0, BUTTON_INDENT);


### PR DESCRIPTION
Added the 'previous' button (an exact counterpart of the 'forward' button), as well as a 'reset time' button to the preview UI controls, as well as keybinds for them.

I was extremely missing those and made them for myself, but then decided to quickly organize that into a PR.

The current ux is pretty weird, reset time is somewhere in the menus, there is a forward button but no backward button.
And I know that technically shaders should use time as a monotonic source and not care about the absolute value, but in my example my time uniform (that I do not control) always goes from 0 to 1, and I also wanted to precisely look at some frames (moving forward and backward) as well as look at how it looks in 60fps (so unbinding time uniform from time and pinning it does not always work), and I mean c'mon those features seem pretty ubiquitous.

