### PR TITLE
fix crash when debugging GLSL geometry shader

### DIFF
--- a/libs/misc/ImFileDialog.cpp
+++ b/libs/misc/ImFileDialog.cpp
@@ -924,6 +924,7 @@ namespace ifd {
 		#endif
 
 		m_clearIconPreview();
+		std::filesystem::path pCopy = p;
 		m_content.clear(); // p == "" after this line, due to reference
 		m_selectedFileItem = -1;
 		
@@ -936,14 +937,14 @@ namespace ifd {
 			m_clearIcons();
 		}
 
-		if (p.u8string() == "Quick Access") {
+		if (pCopy.u8string() == "Quick Access") {
 			for (auto& node : m_treeCache) {
 				if (node->Path == p)
 					for (auto& c : node->Children)
 						m_content.push_back(FileData(c->Path));
 			}
 		} 
-		else if (p.u8string() == "This PC") {
+		else if (pCopy.u8string() == "This PC") {
 			for (auto& node : m_treeCache) {
 				if (node->Path == p)
 					for (auto& c : node->Children)

--- a/main.cpp
+++ b/main.cpp
@@ -78,11 +78,13 @@ int main(int argc, char* argv[])
 	// currently the only supported argument is a path to set the working directory... dont do this check if user wants to explicitly set the working directory,
 	// TODO: if more arguments get added, use different methods to check if working directory is being set explicitly
 	{
-		char result[PATH_MAX];
+		char result[PATH_MAX + 1];
 		ssize_t readlinkRes = readlink("/proc/self/exe", result, PATH_MAX);
 		std::string exePath = "";
-		if (readlinkRes != -1)
+		if (readlinkRes > 0) {
+			result[readlinkRes] = '\0';
 			exePath = std::string(dirname(result));
+		}
 		
 		std::vector<std::string> toCheck = {
 			"/../share/SHADERed",

--- a/src/SHADERed/Engine/GLUtils.cpp
+++ b/src/SHADERed/Engine/GLUtils.cpp
@@ -121,7 +121,8 @@ namespace ed {
 		{
 			int fmtIndex = 0;
 
-			glDeleteVertexArrays(1, &geoVAO);
+			if (geoVAO != 0)
+				glDeleteVertexArrays(1, &geoVAO);
 			glGenVertexArrays(1, &geoVAO);
 
 			glBindVertexArray(geoVAO);
@@ -147,7 +148,8 @@ namespace ed {
 		{
 			int fmtIndex = 0;
 
-			glDeleteVertexArrays(1, &geoVAO);
+			if (geoVAO != 0)
+				glDeleteVertexArrays(1, &geoVAO);
 			glGenVertexArrays(1, &geoVAO);
 
 			glBindVertexArray(geoVAO);

--- a/src/SHADERed/Engine/GeometryFactory.cpp
+++ b/src/SHADERed/Engine/GeometryFactory.cpp
@@ -301,7 +301,7 @@ namespace ed {
 			glBufferData(GL_ARRAY_BUFFER, numPoints * 18 * sizeof(GLfloat), circleData, GL_STATIC_DRAW);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-			GLuint vao;
+			GLuint vao = 0;
 			gl::CreateVAO(vao, vbo, inp);
 
 			return vao;
@@ -330,7 +330,7 @@ namespace ed {
 			glBufferData(GL_ARRAY_BUFFER, 6 * 18 * sizeof(GLfloat), planeData, GL_STATIC_DRAW);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-			GLuint vao;
+			GLuint vao = 0;
 			gl::CreateVAO(vao, vbo, inp);
 
 			return vao;
@@ -364,7 +364,7 @@ namespace ed {
 			glBufferData(GL_ARRAY_BUFFER, count * 18 * sizeof(GLfloat), sphereData, GL_STATIC_DRAW);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-			GLuint vao;
+			GLuint vao = 0;
 			gl::CreateVAO(vao, vbo, inp);
 
 			return vao;
@@ -388,7 +388,7 @@ namespace ed {
 			glBufferData(GL_ARRAY_BUFFER, 3 * 18 * sizeof(GLfloat), triData, GL_STATIC_DRAW);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-			GLuint vao;
+			GLuint vao = 0;
 			gl::CreateVAO(vao, vbo, inp);
 
 			return vao;

--- a/src/SHADERed/InterfaceManager.cpp
+++ b/src/SHADERed/InterfaceManager.cpp
@@ -238,13 +238,6 @@ namespace ed {
 
 		memcpy(pixel.FinalPosition, pixel.VertexShaderPosition, sizeof(glm::vec4) * 3);
 
-		// run the geometry shader if needed
-		if (pixel.GeometryShaderUsed) {
-			Debugger.PrepareGeometryShader(pixel.Pass, pixel.Object);
-			Debugger.SetGeometryShaderInput(pixel);
-			Debugger.ExecuteGeometryShader();
-		}
-
 		// run the tessellation shader if needed
 		if (pixel.TessellationShaderUsed) {
 			Debugger.PrepareTessellationControlShader(pixel.Pass, pixel.Object);
@@ -252,6 +245,13 @@ namespace ed {
 			for (int iid = 0; iid < pixel.VertexCount; iid++)
 				Debugger.ExecuteTessellationControlShader(iid);
 			Debugger.CopyTessellationControlShaderOutput();
+		}
+
+		// run the geometry shader if needed
+		if (pixel.GeometryShaderUsed) {
+			Debugger.PrepareGeometryShader(pixel.Pass, pixel.Object);
+			Debugger.SetGeometryShaderInput(pixel);
+			Debugger.ExecuteGeometryShader();
 		}
 
 		// run pixel shader

--- a/src/SHADERed/Objects/Debug/PixelInformation.h
+++ b/src/SHADERed/Objects/Debug/PixelInformation.h
@@ -71,9 +71,9 @@ namespace ed {
 		bool Discarded; // was this pixel discarded?
 
 		int VertexCount;					// 1 for point, 2 for line, 3 for triangle, etc...
-		eng::Model::Mesh::Vertex Vertex[3]; // vertices that are responsible for this pixel
-		glm::vec4 VertexShaderPosition[3];			// position output from vertex shader
-		std::vector<struct spvm_result> VertexShaderOutput[3];
+		eng::Model::Mesh::Vertex Vertex[6]; // vertices that are responsible for this pixel
+		glm::vec4 VertexShaderPosition[6];			// position output from vertex shader
+		std::vector<struct spvm_result> VertexShaderOutput[6];
 
 		void* InstanceBuffer;
 

--- a/src/SHADERed/Objects/Names.cpp
+++ b/src/SHADERed/Objects/Names.cpp
@@ -22,8 +22,10 @@ const char* TOPOLOGY_ITEM_NAMES[] = {
 	"TriangleStripAdjecent",
 	"Patches"
 };
+// https://www.khronos.org/opengl/wiki/Geometry_Shader
+// https://www.khronos.org/opengl/wiki/Primitive#Patches // TODO patches vertices count depends on tess shaders
 const unsigned char TOPOLOGY_SINGLE_VERTEX_COUNT[] = {
-	0, 1, 2, 2, 3, 3, 2, 2, 3, 3, 3
+	0, 1, 2, 2, 3, 3, 4, 4, 6, 6, 3
 };
 const unsigned char TOPOLOGY_IS_STRIP[] = {
 	0, 0, 0, 1, 0, 2, 0, 1, 0, 2, 0

--- a/src/SHADERed/UI/CodeEditorUI.cpp
+++ b/src/SHADERed/UI/CodeEditorUI.cpp
@@ -35,6 +35,7 @@ namespace ed {
 	CodeEditorUI::CodeEditorUI(GUIManager* ui, ed::InterfaceManager* objects, const std::string& name, bool visible)
 			: UIView(ui, objects, name, visible)
 			, m_selectedItem(-1)
+			, m_trackUpdatesNeeded(0)
 	{
 		Settings& sets = Settings::Instance();
 

--- a/src/SHADERed/UI/Debug/VectorWatchUI.cpp
+++ b/src/SHADERed/UI/Debug/VectorWatchUI.cpp
@@ -52,7 +52,6 @@ namespace ed {
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 		// vao
-		glDeleteVertexArrays(1, &vao);
 		glGenVertexArrays(1, &vao);
 		glBindVertexArray(vao);
 		glBindBuffer(GL_ARRAY_BUFFER, vbo);

--- a/src/SHADERed/UI/PipelineUI.cpp
+++ b/src/SHADERed/UI/PipelineUI.cpp
@@ -772,7 +772,7 @@ namespace ed {
 		ImGui::NextColumn();
 		ImGui::PopStyleColor();
 
-		ImGui::Text("%d", els.size());
+		ImGui::Text("%d", (int)els.size());
 		ImGui::NextColumn();
 
 		/* TYPE */

--- a/src/SHADERed/UI/PipelineUI.h
+++ b/src/SHADERed/UI/PipelineUI.h
@@ -20,6 +20,7 @@ namespace ed {
 			m_isInpLayoutManagerOpened = false;
 			m_isResourceManagerOpened = false;
 			m_isComputeDebugOpen = false;
+			m_isConfirmDeleteOpened = false;
 		}
 
 		virtual void OnEvent(const SDL_Event& e);

--- a/src/SHADERed/UI/PreviewUI.h
+++ b/src/SHADERed/UI/PreviewUI.h
@@ -19,7 +19,10 @@ namespace ed {
 				, m_overlayFBO(0)
 				, m_overlayColor(0)
 				, m_overlayDepth(0)
+				, m_boxVAO(0)
+				, m_boxVBO(0)
 				, m_lastSize(-1, -1)
+				, m_zoomLastSize(-1, -1)
 		{
 			m_setupShortcuts();
 			m_setupBoundingBox();

--- a/src/SHADERed/UI/Tools/DebuggerOutline.cpp
+++ b/src/SHADERed/UI/Tools/DebuggerOutline.cpp
@@ -16,43 +16,49 @@ namespace ed {
 	{
 		unsigned int outlineColor = 0xffffffff;
 		ImDrawList* drawList = ImGui::GetWindowDrawList();
-		
-		glm::ivec2 vertPos1 = (getScreenCoord(pixel.VertexShaderPosition[0]) - zoomPos) * (1.0f / zoomSize) * itemSize;
-		glm::ivec2 vertPos2 = (getScreenCoord(pixel.VertexShaderPosition[1]) - zoomPos) * (1.0f / zoomSize) * itemSize;
-		glm::ivec2 vertPos3 = (getScreenCoord(pixel.VertexShaderPosition[2]) - zoomPos) * (1.0f / zoomSize) * itemSize;
+		glm::ivec2 vPos[6];
+		int i, j;
 
-		vertPos1.y = itemSize.y - vertPos1.y;
-		vertPos2.y = itemSize.y - vertPos2.y;
-		vertPos3.y = itemSize.y - vertPos3.y;
+		for (i = 0; i < pixel.VertexCount; ++i) {
+			vPos[i] = (getScreenCoord(pixel.VertexShaderPosition[i]) - zoomPos) * (1.0f / zoomSize) * itemSize;
+			vPos[i].y = itemSize.y - vPos[i].y;
+		}
 
-		if (pixel.VertexCount > 1) drawList->AddLine(ImVec2(uiPos.x + vertPos1.x, uiPos.y + vertPos1.y), ImVec2(uiPos.x + vertPos2.x, uiPos.y + vertPos2.y), outlineColor);
-		if (pixel.VertexCount > 2) drawList->AddLine(ImVec2(uiPos.x + vertPos2.x, uiPos.y + vertPos2.y), ImVec2(uiPos.x + vertPos3.x, uiPos.y + vertPos3.y), outlineColor);
-		if (pixel.VertexCount > 2) drawList->AddLine(ImVec2(uiPos.x + vertPos3.x, uiPos.y + vertPos3.y), ImVec2(uiPos.x + vertPos1.x, uiPos.y + vertPos1.y), outlineColor);
+		for (i = 0, j = 1; j < pixel.VertexCount; ++i, ++j)
+			drawList->AddLine(ImVec2(uiPos.x + vPos[i].x, uiPos.y + vPos[i].y), ImVec2(uiPos.x + vPos[j].x, uiPos.y + vPos[j].y), outlineColor);
+		if (pixel.VertexCount > 2)
+			drawList->AddLine(ImVec2(uiPos.x + vPos[i].x, uiPos.y + vPos[i].y), ImVec2(uiPos.x + vPos[0].x, uiPos.y + vPos[0].y), outlineColor);
 
-		drawList->AddText(ImVec2(uiPos.x + vertPos1.x, uiPos.y + vertPos1.y), outlineColor, "0");
-		if (pixel.VertexCount >= 2) drawList->AddText(ImVec2(uiPos.x + vertPos2.x, uiPos.y + vertPos2.y), outlineColor, "1");
-		if (pixel.VertexCount > 2) drawList->AddText(ImVec2(uiPos.x + vertPos3.x, uiPos.y + vertPos3.y), outlineColor, "2");
-	
+		for (i = 0; i < pixel.VertexCount; ++i) {
+			const char c[1] = { '0' + i };
+			drawList->AddText(ImVec2(uiPos.x + vPos[i].x, uiPos.y + vPos[i].y), outlineColor, &c[0], &c[1]);
+		}
+
 		if (pixel.GeometryShaderUsed) {
-			if (pixel.GeometryOutputType == GeometryShaderOutput::LineStrip) {
-				glm::ivec2 gsPos1 = (getScreenCoordInverted(pixel.FinalPosition[0]) - glm::vec2(zoomPos.x, -zoomPos.y)) * (1.0f / zoomSize) * itemSize;
-				glm::ivec2 gsPos2 = (getScreenCoordInverted(pixel.FinalPosition[1]) - glm::vec2(zoomPos.x, -zoomPos.y)) * (1.0f / zoomSize) * itemSize;
-				
-				drawList->AddLine(ImVec2(uiPos.x + gsPos1.x, uiPos.y + gsPos1.y), ImVec2(uiPos.x + gsPos2.x, uiPos.y + gsPos2.y), outlineColor);
-				drawList->AddText(ImVec2(uiPos.x + gsPos1.x, uiPos.y + gsPos1.y), outlineColor, "GS0");
-				drawList->AddText(ImVec2(uiPos.x + gsPos2.x, uiPos.y + gsPos2.y), outlineColor, "GS1");
-			}
-			else if (pixel.GeometryOutputType == GeometryShaderOutput::TriangleStrip) {
-				glm::ivec2 gsPos1 = (getScreenCoordInverted(pixel.FinalPosition[0]) - glm::vec2(zoomPos.x, -zoomPos.y)) * (1.0f / zoomSize) * itemSize;
-				glm::ivec2 gsPos2 = (getScreenCoordInverted(pixel.FinalPosition[1]) - glm::vec2(zoomPos.x, -zoomPos.y)) * (1.0f / zoomSize) * itemSize;
-				glm::ivec2 gsPos3 = (getScreenCoordInverted(pixel.FinalPosition[2]) - glm::vec2(zoomPos.x, -zoomPos.y)) * (1.0f / zoomSize) * itemSize;
+			int gsOutputsCount = 0;
+			glm::ivec2 gsPos[3];
 
-				drawList->AddLine(ImVec2(uiPos.x + gsPos1.x, uiPos.y + gsPos1.y), ImVec2(uiPos.x + gsPos2.x, uiPos.y + gsPos2.y), outlineColor);
-				drawList->AddLine(ImVec2(uiPos.x + gsPos2.x, uiPos.y + gsPos2.y), ImVec2(uiPos.x + gsPos3.x, uiPos.y + gsPos3.y), outlineColor);
-				drawList->AddLine(ImVec2(uiPos.x + gsPos3.x, uiPos.y + gsPos3.y), ImVec2(uiPos.x + gsPos1.x, uiPos.y + gsPos1.y), outlineColor);
-				drawList->AddText(ImVec2(uiPos.x + gsPos1.x, uiPos.y + gsPos1.y), outlineColor, "GS0");
-				drawList->AddText(ImVec2(uiPos.x + gsPos2.x, uiPos.y + gsPos2.y), outlineColor, "GS1");
-				drawList->AddText(ImVec2(uiPos.x + gsPos3.x, uiPos.y + gsPos3.y), outlineColor, "GS2");
+			switch (pixel.GeometryOutputType) {
+			case GeometryShaderOutput::Points:
+				gsOutputsCount = 1;
+				break;
+			case GeometryShaderOutput::LineStrip:
+				gsOutputsCount = 2;
+				break;
+			case GeometryShaderOutput::TriangleStrip:
+				gsOutputsCount = 3;
+				break;
+			}
+
+			for (i = 0; i < gsOutputsCount; ++i)
+				gsPos[i] = (getScreenCoordInverted(pixel.FinalPosition[i]) - glm::vec2(zoomPos.x, -zoomPos.y)) * (1.0f / zoomSize) * itemSize;
+			for (i = 0, j = 1; j < gsOutputsCount; ++i, ++j)
+				drawList->AddLine(ImVec2(uiPos.x + gsPos[i].x, uiPos.y + gsPos[i].y), ImVec2(uiPos.x + gsPos[j].x, uiPos.y + gsPos[j].y), outlineColor);
+			if (gsOutputsCount > 2)
+				drawList->AddLine(ImVec2(uiPos.x + gsPos[i].x, uiPos.y + gsPos[i].y), ImVec2(uiPos.x + gsPos[0].x, uiPos.y + gsPos[0].y), outlineColor);
+			for (i = 0; i < gsOutputsCount; ++i) {
+				const char GS0[4] = { 'G', 'S', '0' + i, '\0' };
+				drawList->AddText(ImVec2(uiPos.x + gsPos[i].x, uiPos.y + gsPos[i].y), outlineColor, GS0);
 			}
 		}
 	}


### PR DESCRIPTION
SHAREDed crashed when debugging a geometry shader with lines_adjacency input in a VertexBuffer.
+ fixed UI/DebugOutline for lines_adjacency
+ InterfaceManager.cpp, moved geometry code after tesselation
+ added a bunch of minor fixes after valgrind/memcheck session, in order to ease further debugging