### PR TITLE
Fix uncompressed DDS volumes missing first few pixels

### DIFF
--- a/libs/misc/dds.c
+++ b/libs/misc/dds.c
@@ -63,7 +63,7 @@ void dds_parse_uncompressed(dds_image_t image, const char* data, long data_lengt
 
 	dds_byte bytes_per_pixel = image->header.pixel_format.rgb_bit_count / 8;
 
-	data += img_width * 4; // huh? without this there's gibberish in the first row of the image... am I missing something?
+	data += 128; // Skip the header
 
 	// read the actual data
 	for (dds_uint z = 0; z < img_depth; z++) 


### PR DESCRIPTION
I attempted to load an uncompressed DDS volume, but part of the first few rows were missing. I've attached the .dds file I was using. I set the very first pixel to yellow so it was easy to see where it starts. GIMP can be used to view it.

[terrain-dds.zip](https://github.com/dfranx/SHADERed/files/6721134/terrain-dds.zip)

This patch seems to fix it. I'm not 100% sure how it all works, but I think the 128 bytes is the header mentioned here: https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-file-layout-for-volume-textures

Perhaps your test image was coincidentally 32 pixels wide?

Screenshot of the bug:
![image](https://user-images.githubusercontent.com/3372/123535224-991f2500-d776-11eb-9440-4de86973c714.png)

Screenshot of the fixed version:
![image](https://user-images.githubusercontent.com/3372/123535204-84429180-d776-11eb-824c-6dae160445d9.png)
