### PR TITLE
Add IPlugin3 with RegisterPlugin

### DIFF
--- a/src/SHADERed/Objects/PluginAPI/Plugin.h
+++ b/src/SHADERed/Objects/PluginAPI/Plugin.h
@@ -142,6 +142,9 @@ namespace ed {
 		typedef bool (*ImGuiFileDialogGetResultFn)();
 		typedef void (*ImGuiFileDialogGetPathFn)(char* outPath);
 		typedef const char* (*DebuggerImmediateFn)(void* Debugger, const char* expr);
+
+		/********** IPlugin3 **********/
+		typedef void (*RegisterPlugin)(void* pluginManager, void* plugin, const char* pname, int apiVer, int pluginVer, void* procDLL);
 	}
 
 	// CreatePlugin(), DestroyPlugin(ptr), GetPluginAPIVersion(), GetPluginVersion(), GetPluginName()
@@ -469,5 +472,14 @@ namespace ed {
 		pluginfn::ImGuiFileDialogGetResultFn ImGuiFileDialogGetResult;
 		pluginfn::ImGuiFileDialogGetPathFn ImGuiFileDialogGetPath;
 		pluginfn::DebuggerImmediateFn DebuggerImmediate;
+	};
+
+	class IPlugin3 : public IPlugin2 {
+	public:
+		virtual int GetVersion() { return 3; }
+
+		virtual void PluginManager_RegisterPlugins() = 0;
+
+		pluginfn::RegisterPlugin RegisterPlugin;
 	};
 }

--- a/src/SHADERed/Objects/PluginManager.cpp
+++ b/src/SHADERed/Objects/PluginManager.cpp
@@ -51,6 +51,9 @@ namespace ed {
 	}
 	void PluginManager::Init(InterfaceManager* data, GUIManager* ui)
 	{
+		m_data = data;
+		m_ui = ui;
+		
 		std::string pluginsDirLoc = Settings::Instance().ConvertPath("plugins/");
 
 		if (!std::filesystem::exists(pluginsDirLoc)) {
@@ -61,10 +64,9 @@ namespace ed {
 		std::string settingsFileLoc = ed::Settings::Instance().ConvertPath("data/plugin_settings.ini");
 
 		std::ifstream ini(settingsFileLoc);
-		std::vector<std::string> iniLines;
 		std::copy(std::istream_iterator<std::string>(ini),
 			std::istream_iterator<std::string>(),
-			std::back_inserter(iniLines));
+			std::back_inserter(m_iniLines));
 		ini.close();
 
 		std::string pluginExt = "dll";
@@ -166,838 +168,9 @@ namespace ed {
 					(*ptrFreeLibrary)(procDLL);
 					continue;
 				}
-
-				// set up pointers to app functions
-				plugin->ObjectManager = (void*)&data->Objects;
-				plugin->PipelineManager = (void*)&data->Pipeline;
-				plugin->Renderer = (void*)&data->Renderer;
-				plugin->Messages = (void*)&data->Messages;
-				plugin->Project = (void*)&data->Parser;
-				plugin->Debugger = (void*)&data->Debugger;
-				plugin->UI = (void*)ui;
-				plugin->Plugins = (void*)this;
-
-				plugin->AddObject = [](void* objectManager, const char* name, const char* type, void* data, unsigned int id, void* owner) {
-					ObjectManager* objm = (ObjectManager*)objectManager;
-					objm->CreatePluginItem(name, type, data, id, (IPlugin1*)owner);
-				};
-				plugin->AddCustomPipelineItem = [](void* pipeManager, void* parentPtr, const char* name, const char* type, void* data, void* owner) -> bool {
-					PipelineManager* pipe = (PipelineManager*)pipeManager;
-					PipelineItem* parent = (PipelineItem*)parentPtr;
-					char* parentName = nullptr;
-
-					if (parent != nullptr)
-						parentName = parent->Name;
-
-					return pipe->AddPluginItem(parentName, name, type, data, (IPlugin1*)owner);
-				};
-				plugin->AddMessage = [](void* messages, plugin::MessageType mtype, const char* group, const char* txt, int ln) {
-					MessageStack* msgs = (MessageStack*)messages;
-					std::string groupStr = "";
-					if (group != nullptr)
-						groupStr = std::string(group);
-					msgs->Add((MessageStack::Type)mtype, groupStr, txt, ln);
-				};
-				plugin->CreateRenderTexture = [](void* objects, const char* name) -> bool {
-					ObjectManager* objs = (ObjectManager*)objects;
-					return objs->CreateRenderTexture(name);
-				};
-				plugin->CreateImage = [](void* objects, const char* name, int width, int height) -> bool {
-					ObjectManager* objs = (ObjectManager*)objects;
-					return objs->CreateImage(name, glm::ivec2(width, height));
-				};
-				plugin->ResizeRenderTexture = [](void* objects, const char* name, int width, int height) {
-					ObjectManager* objs = (ObjectManager*)objects;
-					objs->ResizeRenderTexture(objs->Get(name), glm::ivec2(width, height));
-				};
-				plugin->ResizeImage = [](void* objects, const char* name, int width, int height) {
-					ObjectManager* objs = (ObjectManager*)objects;
-					objs->ResizeImage(objs->Get(name), glm::ivec2(width, height));
-				};
-				plugin->ExistsObject = [](void* objects, const char* name) -> bool {
-					ObjectManager* objs = (ObjectManager*)objects;
-					return objs->Exists(name);
-				};
-				plugin->RemoveGlobalObject = [](void* objects, const char* name) {
-					ObjectManager* objs = (ObjectManager*)objects;
-					objs->Remove(name);
-				};
-				plugin->GetProjectPath = [](void* project, const char* filename, char* out) {
-					ProjectParser* proj = (ProjectParser*)project;
-					std::string path = proj->GetProjectPath(filename);
-					strcpy(out, path.c_str());
-				};
-				plugin->GetRelativePath = [](void* project, const char* filename, char* out) {
-					ProjectParser* proj = (ProjectParser*)project;
-					std::string path = proj->GetRelativePath(filename);
-					strcpy(out, path.c_str());
-				};
-				plugin->GetProjectFilename = [](void* project, char* out) {
-					ProjectParser* proj = (ProjectParser*)project;
-					std::string path = proj->GetOpenedFile();
-					strcpy(out, path.c_str());
-				};
-				plugin->GetProjectDirectory = [](void* project) -> const char* {
-					ProjectParser* proj = (ProjectParser*)project;
-					return proj->GetProjectDirectory().c_str();
-				};
-				plugin->IsProjectModified = [](void* project) -> bool {
-					ProjectParser* proj = (ProjectParser*)project;
-					return proj->IsProjectModified();
-				};
-				plugin->ModifyProject = [](void* project) {
-					ProjectParser* proj = (ProjectParser*)project;
-					proj->ModifyProject();
-				};
-				plugin->OpenProject = [](void* uiData, const char* filename) {
-					GUIManager* ui = (GUIManager*)uiData;
-					ui->Open(filename);
-				};
-				plugin->SaveProject = [](void* project) {
-					ProjectParser* proj = (ProjectParser*)project;
-					proj->Save();
-				};
-				plugin->SaveAsProject = [](void* project, const char* filename, bool copyFiles) {
-					ProjectParser* proj = (ProjectParser*)project;
-					proj->SaveAs(filename, copyFiles);
-				};
-				plugin->IsPaused = [](void* renderer) -> bool {
-					RenderEngine* rend = (RenderEngine*)renderer;
-					return rend->IsPaused();
-				};
-				plugin->Pause = [](void* renderer, bool state) {
-					RenderEngine* rend = (RenderEngine*)renderer;
-					rend->Pause(state);
-				};
-				plugin->GetWindowColorTexture = [](void* renderer) -> unsigned int {
-					RenderEngine* rend = (RenderEngine*)renderer;
-					return rend->GetTexture();
-				};
-				plugin->GetWindowDepthTexture = [](void* renderer) -> unsigned int {
-					RenderEngine* rend = (RenderEngine*)renderer;
-					return rend->GetDepthTexture();
-				};
-				plugin->GetLastRenderSize = [](void* renderer, int& w, int& h) {
-					RenderEngine* rend = (RenderEngine*)renderer;
-					glm::ivec2 sz = rend->GetLastRenderSize();
-					w = sz.x;
-					h = sz.y;
-				};
-				plugin->Render = [](void* renderer, int w, int h) {
-					RenderEngine* rend = (RenderEngine*)renderer;
-					rend->Render(w, h);
-				};
-				plugin->ExistsPipelineItem = [](void* pipeline, const char* name) -> bool {
-					PipelineManager* pipe = (PipelineManager*)pipeline;
-					return pipe->Has(name);
-				};
-				plugin->GetPipelineItem = [](void* pipeline, const char* name) -> void* {
-					PipelineManager* pipe = (PipelineManager*)pipeline;
-					return (void*)pipe->Get(name);
-				};
-				plugin->BindShaderPassVariables = [](void* shaderpass, void* item) {
-					pipe::ShaderPass* data = (pipe::ShaderPass*)shaderpass;
-					data->Variables.Bind(item);
-				};
-				plugin->GetViewMatrix = [](float* out) {
-					glm::mat4 viewm = SystemVariableManager::Instance().GetViewMatrix();
-					memcpy(out, glm::value_ptr(viewm), sizeof(float) * 4 * 4);
-				};
-				plugin->GetProjectionMatrix = [](float* out) {
-					glm::mat4 projm = SystemVariableManager::Instance().GetProjectionMatrix();
-					memcpy(out, glm::value_ptr(projm), sizeof(float) * 4 * 4);
-				};
-				plugin->GetOrthographicMatrix = [](float* out) {
-					glm::mat4 orthom = SystemVariableManager::Instance().GetOrthographicMatrix();
-					memcpy(out, glm::value_ptr(orthom), sizeof(float) * 4 * 4);
-				};
-				plugin->GetViewportSize = [](float& w, float& h) {
-					glm::vec2 viewsize = SystemVariableManager::Instance().GetViewportSize();
-					w = viewsize.x;
-					h = viewsize.y;
-				};
-				plugin->AdvanceTimer = [](float t) {
-					SystemVariableManager::Instance().AdvanceTimer(t);
-				};
-				plugin->GetMousePosition = [](float& x, float& y) {
-					glm::vec2 mpos = SystemVariableManager::Instance().GetMousePosition();
-					x = mpos.x;
-					y = mpos.y;
-				};
-				plugin->GetFrameIndex = []() -> int {
-					return SystemVariableManager::Instance().GetFrameIndex();
-				};
-				plugin->GetTime = []() -> float {
-					return SystemVariableManager::Instance().GetTime();
-				};
-				plugin->SetTime = [](float time) {
-					float curTime = SystemVariableManager::Instance().GetTime();
-					SystemVariableManager::Instance().AdvanceTimer(time - curTime);
-				};
-				plugin->SetGeometryTransform = [](void* item, float scale[3], float rota[3], float pos[3]) {
-					SystemVariableManager::Instance().SetGeometryTransform((PipelineItem*)item, glm::make_vec3(scale), glm::make_vec3(rota), glm::make_vec3(pos));
-				};
-				plugin->SetMousePosition = [](float x, float y) {
-					SystemVariableManager::Instance().SetMousePosition(x, y);
-				};
-				plugin->SetKeysWASD = [](bool w, bool a, bool s, bool d) {
-					SystemVariableManager::Instance().SetKeysWASD(w, a, s, d);
-				};
-				plugin->SetFrameIndex = [](int findex) {
-					SystemVariableManager::Instance().SetFrameIndex(findex);
-				};
-				plugin->GetDPI = []() -> float {
-					return Settings::Instance().DPIScale;
-				};
-				plugin->FileExists = [](void* project, const char* filename) -> bool {
-					ProjectParser* proj = (ProjectParser*)project;
-					return proj->FileExists(filename);
-				};
-				plugin->ClearMessageGroup = [](void* project, const char* group) {
-					MessageStack* msgs = (MessageStack*)project;
-					msgs->ClearGroup(group);
-				};
-				plugin->Log = [](const char* msg, bool error, const char* file, int line) {
-					printf("%s\n", msg);
-					//ed::Logger::Get().Log(msg, error, file, line);
-				};
-				plugin->GetObjectCount = [](void* objects) -> int {
-					ObjectManager* obj = (ObjectManager*)objects;
-					return obj->GetObjects().size();
-				};
-				plugin->GetObjectName = [](void* objects, int index) -> const char* {
-					ObjectManager* obj = (ObjectManager*)objects;
-					return obj->GetObjects()[index]->Name.c_str();
-				};
-				plugin->IsTexture = [](void* objects, const char* name) -> bool {
-					ObjectManager* obj = (ObjectManager*)objects;
-					
-					return obj->Get(name)->Type == ObjectType::Texture;
-				};
-				plugin->GetTexture = [](void* objects, const char* name) -> unsigned int {
-					ObjectManager* obj = (ObjectManager*)objects;
-					return obj->Get(name)->Texture;
-				};
-				plugin->GetFlippedTexture = [](void* objects, const char* name) -> unsigned int {
-					ObjectManager* obj = (ObjectManager*)objects;
-					return obj->Get(name)->FlippedTexture;
-				};
-				plugin->GetTextureSize = [](void* objects, const char* name, int& w, int& h) {
-					ObjectManager* obj = (ObjectManager*)objects;
-					glm::ivec2 tsize = obj->Get(name)->TextureSize;
-					w = tsize.x;
-					h = tsize.y;
-				};
-				plugin->BindDefaultState = []() {
-					DefaultState::Bind();
-				};
-				plugin->OpenInCodeEditor = [](void* ui, void* item, const char* filename, int id) {
-					CodeEditorUI* editor = (CodeEditorUI*)((GUIManager*)ui)->Get(ViewID::Code);
-					editor->OpenPluginCode((PipelineItem*)item, filename, id);
-				};
-				plugin->GetPipelineItemCount = [](void* pipeline) -> int {
-					PipelineManager* pipe = (PipelineManager*)pipeline;
-					return pipe->GetList().size();
-				};
-				plugin->GetPipelineItemType = [](void* item) -> plugin::PipelineItemType {
-					return (plugin::PipelineItemType)((PipelineItem*)item)->Type;
-				};
-				plugin->GetPipelineItemByIndex = [](void* pipeline, int index) -> void* {
-					PipelineManager* pipe = (PipelineManager*)pipeline;
-					return (void*)pipe->GetList()[index];
-				};
-				plugin->DEPRECATED_GetOpenDirectoryDialog = [](char* out) -> bool {
-					return false;
-				};
-				plugin->DEPRECATED_GetOpenFileDialog = [](char* out, const char* files) -> bool {
-					return false;
-				};
-				plugin->DEPRECATED_GetSaveFileDialog = [](char* out, const char* files) -> bool {
-					return false;
-				};
-				plugin->GetIncludePathCount = []() -> int {
-					return Settings::Instance().Project.IncludePaths.size();
-				};
-				plugin->GetIncludePath = [](void* project, int index) -> const char* {
-					return Settings::Instance().Project.IncludePaths[index].c_str();
-				};
-				plugin->GetMessagesCurrentItem = [](void* messages) -> const char* {
-					return ((ed::MessageStack*)messages)->CurrentItem.c_str();
-				};
-				plugin->OnEditorContentChange = nullptr; // will be set by CodeEditorUI
-				plugin->GetPipelineItemSPIRV = [](void* item, plugin::ShaderStage stage, int* len) -> unsigned int* {
-					PipelineItem* pItem = (PipelineItem*)item;
-					if (pItem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* data = (pipe::ShaderPass*)pItem->Data;
-
-						if (stage == plugin::ShaderStage::Pixel) {
-							*len = data->PSSPV.size();
-							return data->PSSPV.data();
-						} else if (stage == plugin::ShaderStage::Vertex) {
-							*len = data->VSSPV.size();
-							return data->VSSPV.data();
-						} else if (stage == plugin::ShaderStage::Geometry) {
-							*len = data->GSSPV.size();
-							return data->GSSPV.data();
-						} else if (stage == plugin::ShaderStage::TessellationControl) {
-							*len = data->TCSSPV.size();
-							return data->TCSSPV.data();
-						} else if (stage == plugin::ShaderStage::TessellationEvaluation) {
-							*len = data->TESSPV.size();
-							return data->TESSPV.data();
-						}
-					} else if (pItem->Type == PipelineItem::ItemType::ComputePass) {
-						pipe::ComputePass* data = (pipe::ComputePass*)pItem->Data;
-
-						*len = data->SPV.size();
-						return data->SPV.data();
-					}
-
-					*len = 0;
-					return nullptr;
-				};
-				plugin->RegisterShortcut = [](void* plugin, const char* name) {
-					KeyboardShortcuts::Instance().RegisterPluginShortcut((IPlugin1*)plugin, std::string(name));
-				};
-				plugin->GetSettingsBoolean = [](const char* name) -> bool {
-					const Settings& seti = Settings::Instance();
-
-					std::string lwr(name);
-					std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
-
-					/* GENERAL */
-					if (lwr == "vsync") return seti.General.VSync;
-					if (lwr == "autoopenerrorwindow") return seti.General.AutoOpenErrorWindow;
-					if (lwr == "toolbar") return seti.General.Toolbar;
-					if (lwr == "recovery") return seti.General.Recovery;
-					if (lwr == "checkupdates") return seti.General.CheckUpdates;
-					if (lwr == "recompileonfilechange") return seti.General.RecompileOnFileChange;
-					if (lwr == "autorecompile") return seti.General.AutoRecompile;
-					if (lwr == "autouniforms") return seti.General.AutoUniforms;
-					if (lwr == "autouniformspin") return seti.General.AutoUniformsPin;
-					if (lwr == "autouniformsfunction") return seti.General.AutoUniformsFunction;
-					if (lwr == "autouniformsdelete") return seti.General.AutoUniformsDelete;
-					if (lwr == "reopenshaders") return seti.General.ReopenShaders;
-					if (lwr == "useexternaleditor") return seti.General.UseExternalEditor;
-					if (lwr == "openshadersondblclk") return seti.General.OpenShadersOnDblClk;
-					if (lwr == "itempropsondblclk") return seti.General.ItemPropsOnDblCLk;
-					if (lwr == "selectitemondblclk") return seti.General.SelectItemOnDblClk;
-					if (lwr == "log") return seti.General.Log;
-					if (lwr == "streamlogs") return seti.General.StreamLogs;
-					if (lwr == "pipelogstoterminal") return seti.General.PipeLogsToTerminal;
-					if (lwr == "autoscale") return seti.General.AutoScale;
-					if (lwr == "tips") return seti.General.Tips;
-
-					/* EDITOR */
-					if (lwr == "smartpredictions") return seti.Editor.SmartPredictions;
-					if (lwr == "activesmartpredictions") return seti.Editor.ActiveSmartPredictions;
-					if (lwr == "showwhitespace") return seti.Editor.ShowWhitespace;
-					if (lwr == "highlightcurrentline") return seti.Editor.HiglightCurrentLine;
-					if (lwr == "linenumbers") return seti.Editor.LineNumbers;
-					if (lwr == "statusbar") return seti.Editor.StatusBar;
-					if (lwr == "horizontalscroll") return seti.Editor.HorizontalScroll;
-					if (lwr == "autobracecompletion") return seti.Editor.AutoBraceCompletion;
-					if (lwr == "smartindent") return seti.Editor.SmartIndent;
-					if (lwr == "autoindentonpaste") return seti.Editor.AutoIndentOnPaste;
-					if (lwr == "insertspaces") return seti.Editor.InsertSpaces;
-					if (lwr == "functiontooltips") return seti.Editor.FunctionTooltips;
-					if (lwr == "syntaxhighlighting") return seti.Editor.SyntaxHighlighting;
-
-					/* DEBUG */
-					if (lwr == "showvaluesonhover") return seti.Debug.ShowValuesOnHover;
-					if (lwr == "autofetch") return seti.Debug.AutoFetch;
-					if (lwr == "primitiveoutline") return seti.Debug.PrimitiveOutline;
-					if (lwr == "pixeloutline") return seti.Debug.PixelOutline;
-
-					/* PREVIEW */
-					if (lwr == "pausedonstartup") return seti.Preview.PausedOnStartup;
-					if (lwr == "switchleftrightclick") return seti.Preview.SwitchLeftRightClick;
-					if (lwr == "hidemenuinperformancemode") return seti.Preview.HideMenuInPerformanceMode;
-					if (lwr == "boundingbox") return seti.Preview.BoundingBox;
-					if (lwr == "gizmo") return seti.Preview.Gizmo;
-					if (lwr == "gizmorotationui") return seti.Preview.GizmoRotationUI;
-					if (lwr == "propertypick") return seti.Preview.PropertyPick;
-					if (lwr == "statusbar") return seti.Preview.StatusBar;
-					if (lwr == "applyfpslimittoapp") return seti.Preview.ApplyFPSLimitToApp;
-					if (lwr == "lostfocuslimitfps") return seti.Preview.LostFocusLimitFPS;
-
-					/* PROJECT */
-					if (lwr == "fpcamera") return seti.Project.FPCamera;
-					if (lwr == "usealphachannel") return seti.Project.UseAlphaChannel;
-
-					return false;
-				};
-				plugin->GetSettingsInteger = [](const char* name) -> int {
-					const Settings& seti = Settings::Instance();
-
-					std::string lwr(name);
-					std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
-
-					/* GENERAL */
-					if (lwr == "fontsize") return seti.General.FontSize;
-
-					/* EDITOR */
-					if (lwr == "editorfontsize") return seti.Editor.FontSize;
-					if (lwr == "tabsize") return seti.Editor.TabSize;
-
-					/* PREVIEW */
-					if (lwr == "gizmosnaptranslation") return seti.Preview.GizmoSnapTranslation;
-					if (lwr == "gizmosnapscale") return seti.Preview.GizmoSnapScale;
-					if (lwr == "gizmosnaprotation") return seti.Preview.GizmoSnapRotation;
-					if (lwr == "fpslimit") return seti.Preview.FPSLimit;
-					if (lwr == "msaa") return seti.Preview.MSAA;
-
-					return -1;
-				};
-				plugin->GetSettingsString = [](const char* name) -> const char* {
-					const Settings& seti = Settings::Instance();
-
-					std::string lwr(name);
-					std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
-
-					/* GENERAL */
-					if (lwr == "startuptemplate") return seti.General.StartUpTemplate.c_str();
-					if (lwr == "font") return seti.General.Font;
-
-					/* EDITOR */
-					if (lwr == "editorfont") return seti.Editor.Font;
-
-					return nullptr;
-				};
-				plugin->GetSettingsFloat = [](const char* name) -> float {
-					const Settings& seti = Settings::Instance();
-
-					std::string lwr(name);
-					std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
-
-					if (lwr == "clearcolorr") return seti.Project.ClearColor.r;
-					if (lwr == "clearcolorg") return seti.Project.ClearColor.g;
-					if (lwr == "clearcolorb") return seti.Project.ClearColor.b;
-					if (lwr == "clearcolora") return seti.Project.ClearColor.a;
-
-					return 0.0f;
-				};
-				plugin->GetPreviewUIRect = [](void* ui, float* out) {
-					PreviewUI* preview = (PreviewUI*)(((GUIManager*)ui)->Get(ViewID::Preview));
-					glm::vec2 pos = preview->GetUIRectPosition();
-					glm::vec2 size = preview->GetUIRectSize();
-					out[0] = pos.x;
-					out[1] = pos.y;
-					out[2] = size.x;
-					out[3] = size.y;
-				};
-				plugin->GetPlugin = [](void* pluginManager, const char* name) -> void* {
-					return (void*)((PluginManager*)pluginManager)->GetPlugin(name);
-				};
-				plugin->GetPluginListSize = [](void* pluginManager) -> int {
-					return ((PluginManager*)pluginManager)->Plugins().size();
-				};
-				plugin->GetPluginName = [](void* pluginManager, int index) -> const char* {
-					PluginManager* pl = (PluginManager*)pluginManager;
-					if (index >= pl->Plugins().size() || index <= 0)
-						return nullptr;
-					return pl->GetPluginName(pl->Plugins()[index]).c_str();
-				};
-				plugin->SendPluginMessage = [](void* pluginManager, void* plugin, const char* receiver, char* msg, int msgLen) {
-					PluginManager* pl = (PluginManager*)pluginManager;
-					IPlugin1* receiverPlugin = pl->GetPlugin(receiver);
-
-					if (receiverPlugin)
-						receiverPlugin->HandlePluginMessage(pl->GetPluginName((IPlugin1*)plugin).c_str(), msg, msgLen);
-				};
-				plugin->BroadcastPluginMessage = [](void* pluginManager, void* plugin, char* msg, int msgLen) {
-					PluginManager* pl = (PluginManager*)pluginManager;
-					const char* myName = pl->GetPluginName((IPlugin1*)plugin).c_str();
-					for (auto& p : pl->Plugins())
-						p->HandlePluginMessage(myName, msg, msgLen);
-				};
-				plugin->ToggleFullscreen = [](void* UI) {
-					SDL_Window* wnd = ((GUIManager*)UI)->GetSDLWindow();
-					Uint32 wndFlags = SDL_GetWindowFlags(wnd);
-					bool isFullscreen = wndFlags & SDL_WINDOW_FULLSCREEN_DESKTOP;
-					SDL_SetWindowFullscreen(wnd, (!isFullscreen) * SDL_WINDOW_FULLSCREEN_DESKTOP);
-				};
-				plugin->IsFullscreen = [](void* UI) -> bool {
-					SDL_Window* wnd = ((GUIManager*)UI)->GetSDLWindow();
-					return SDL_GetWindowFlags(wnd) & SDL_WINDOW_FULLSCREEN_DESKTOP;
-				};
-				plugin->TogglePerformanceMode = [](void* UI) {
-					((GUIManager*)UI)->SetPerformanceMode(!((GUIManager*)UI)->IsPerformanceMode());
-				};
-				plugin->IsInPerformanceMode = [](void* UI) -> bool {
-					return ((GUIManager*)UI)->IsPerformanceMode();
-				};
-				plugin->GetPipelineItemName = [](void* item) -> const char* {
-					return ((PipelineItem*)item)->Name;
-				};
-				plugin->GetPipelineItemPluginOwner = [](void* item) -> void* {
-					PipelineItem* pitem = ((PipelineItem*)item);
-					if (pitem->Type == PipelineItem::ItemType::PluginItem)
-						return ((pipe::PluginItemData*)pitem->Data)->Owner;
-					return nullptr;
-				};
-				plugin->GetPipelineItemVariableCount = [](void* item) -> int {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
-						return pass->Variables.GetVariables().size();
-					} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
-						pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
-						return pass->Variables.GetVariables().size();
-					} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
-						pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
-						return pass->Variables.GetVariables().size();
-					}
-
-					return 0;
-				};
-				plugin->GetPipelineItemVariableName = [](void* item, int index) -> const char* {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
-						return pass->Variables.GetVariables()[index]->Name;
-					} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
-						pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
-						return pass->Variables.GetVariables()[index]->Name;
-					} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
-						pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
-						return pass->Variables.GetVariables()[index]->Name;
-					}
-
-					return nullptr;
-				};
-				plugin->GetPipelineItemVariableValue = [](void* item, int index) -> char* {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
-						return pass->Variables.GetVariables()[index]->Data;
-					} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
-						pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
-						return pass->Variables.GetVariables()[index]->Data;
-					} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
-						pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
-						return pass->Variables.GetVariables()[index]->Data;
-					}
-
-					return nullptr;
-				};
-				plugin->GetPipelineItemVariableType = [](void* item, int index) -> plugin::VariableType {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
-						return (plugin::VariableType)pass->Variables.GetVariables()[index]->GetType();
-					} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
-						pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
-						return (plugin::VariableType)pass->Variables.GetVariables()[index]->GetType();
-					} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
-						pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
-						return (plugin::VariableType)pass->Variables.GetVariables()[index]->GetType();
-					}
-
-					return plugin::VariableType::Float1;
-				};
-				plugin->AddPipelineItemVariable = [](void* item, const char* name, plugin::VariableType type) -> bool {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
-						if (pass->Variables.ContainsVariable(name)) return false;
-						pass->Variables.AddCopy(ed::ShaderVariable((ed::ShaderVariable::ValueType)type, name));
-						return true;
-					} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
-						pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
-						if (pass->Variables.ContainsVariable(name)) return false;
-						pass->Variables.AddCopy(ed::ShaderVariable((ed::ShaderVariable::ValueType)type, name));
-						return true;
-					} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
-						pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
-						if (pass->Variables.ContainsVariable(name)) return false;
-						pass->Variables.AddCopy(ed::ShaderVariable((ed::ShaderVariable::ValueType)type, name));
-						return true;
-					}
-
-					return false;
-				};
-				plugin->GetPipelineItemChildrenCount = [](void* item) -> int {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
-						return pass->Items.size();
-					} else if (pitem->Type == PipelineItem::ItemType::PluginItem) {
-						pipe::PluginItemData* pass = (pipe::PluginItemData*)pitem->Data;
-						return pass->Items.size();
-					}
-
-					return 0;
-				};
-				plugin->GetPipelineItemChild = [](void* item, int index) -> void* {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
-						pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
-						return pass->Items[index];
-					} else if (pitem->Type == PipelineItem::ItemType::PluginItem) {
-						pipe::PluginItemData* pass = (pipe::PluginItemData*)pitem->Data;
-						return pass->Items[index];
-					}
-
-					return nullptr;
-				};
-				plugin->SetPipelineItemPosition = [](void* item, float x, float y, float z) {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::Geometry) {
-						pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
-						item->Position = glm::vec3(x, y, z);
-					} else if (pitem->Type == PipelineItem::ItemType::Model) {
-						pipe::Model* item = (pipe::Model*)pitem->Data;
-						item->Position = glm::vec3(x, y, z);
-					}
-				};
-				plugin->SetPipelineItemRotation = [](void* item, float x, float y, float z) {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::Geometry) {
-						pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
-						item->Rotation = glm::vec3(x, y, z);
-					} else if (pitem->Type == PipelineItem::ItemType::Model) {
-						pipe::Model* item = (pipe::Model*)pitem->Data;
-						item->Rotation = glm::vec3(x, y, z);
-					}
-				};
-				plugin->SetPipelineItemScale = [](void* item, float x, float y, float z) {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::Geometry) {
-						pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
-						item->Scale = glm::vec3(x, y, z);
-					} else if (pitem->Type == PipelineItem::ItemType::Model) {
-						pipe::Model* item = (pipe::Model*)pitem->Data;
-						item->Scale = glm::vec3(x, y, z);
-					}
-				};
-				plugin->GetPipelineItemPosition = [](void* item, float* data) {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::Geometry) {
-						pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
-						data[0] = item->Position.x;
-						data[1] = item->Position.y;
-						data[2] = item->Position.z;
-					} else if (pitem->Type == PipelineItem::ItemType::Model) {
-						pipe::Model* item = (pipe::Model*)pitem->Data;
-						data[0] = item->Position.x;
-						data[1] = item->Position.y;
-						data[2] = item->Position.z;
-					}
-				};
-				plugin->GetPipelineItemRotation = [](void* item, float* data) {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::Geometry) {
-						pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
-						data[0] = item->Rotation.x;
-						data[1] = item->Rotation.y;
-						data[2] = item->Rotation.z;
-					} else if (pitem->Type == PipelineItem::ItemType::Model) {
-						pipe::Model* item = (pipe::Model*)pitem->Data;
-						data[0] = item->Rotation.x;
-						data[1] = item->Rotation.y;
-						data[2] = item->Rotation.z;
-					}
-				};
-				plugin->GetPipelineItemScale = [](void* item, float* data) {
-					PipelineItem* pitem = ((PipelineItem*)item);
-
-					if (pitem->Type == PipelineItem::ItemType::Geometry) {
-						pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
-						data[0] = item->Scale.x;
-						data[1] = item->Scale.y;
-						data[2] = item->Scale.z;
-					} else if (pitem->Type == PipelineItem::ItemType::Model) {
-						pipe::Model* item = (pipe::Model*)pitem->Data;
-						data[0] = item->Scale.x;
-						data[1] = item->Scale.y;
-						data[2] = item->Scale.z;
-					}
-				};
-				plugin->PushNotification = [](void* UI, void* plugin, int id, const char* text, const char* btn) {
-					((GUIManager*)UI)->AddNotification(
-						id, text, btn, [](int id, IPlugin1* pl) {
-							pl->HandleNotification(id);
-						},
-						(IPlugin1*)plugin);
-				};
-				plugin->DebuggerJump = [](void* Debugger, void* ed, int line) {
-					((ed::DebugInformation*)Debugger)->Jump(line);
-					int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
-					((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
-				};
-				plugin->DebuggerContinue = [](void* Debugger, void* ed) {
-					((ed::DebugInformation*)Debugger)->Continue();
-					int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
-					((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
-				};
-				plugin->DebuggerStep = [](void* Debugger, void* ed) {
-					((ed::DebugInformation*)Debugger)->Step();
-					int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
-					((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
-				};
-				plugin->DebuggerStepInto = [](void* Debugger, void* ed) {
-					((ed::DebugInformation*)Debugger)->StepInto();
-					int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
-					((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
-				};
-				plugin->DebuggerStepOut = [](void* Debugger, void* ed) {
-					((ed::DebugInformation*)Debugger)->StepOut();
-					int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
-					((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
-				};
-				plugin->DebuggerCheckBreakpoint = [](void* Debugger, void* ed, int line) -> bool {
-					return ((ed::DebugInformation*)Debugger)->CheckBreakpoint(line);
-				};
-				plugin->DebuggerIsDebugging = [](void* Debugger, void* ed) -> bool {
-					return ((ed::DebugInformation*)Debugger)->IsDebugging();
-				};
-				plugin->DebuggerGetCurrentLine = [](void* Debugger) -> int {
-					return ((ed::DebugInformation*)Debugger)->GetCurrentLine();
-				};
-				plugin->IsRenderTexture = [](void* objects, const char* name) -> bool {
-					ObjectManager* obj = (ObjectManager*)objects;
-					ObjectManagerItem* item = obj->Get(name);
-
-					if (item && item->RT != nullptr)
-						return true;
-
-					return false;
-				};
-				plugin->GetRenderTextureSize = [](void* objects, const char* name, int& w, int& h) {
-					ObjectManager* obj = (ObjectManager*)objects;
-					ObjectManagerItem* item = obj->Get(name);
-					glm::ivec2 tsize = obj->GetRenderTextureSize(item);
-					w = tsize.x;
-					h = tsize.y;
-				};
-				plugin->GetDepthTexture = [](void* objects, const char* name) -> unsigned int {
-					ObjectManager* obj = (ObjectManager*)objects;
-					return obj->Get(name)->RT->DepthStencilBuffer;
-				};
-				plugin->ScaleSize = [](float size) -> float {
-					return Settings::Instance().CalculateSize(size);
-				};
-
-				if (plugin->GetVersion() >= 2) {
-					ed::IPlugin2* plugin2 = (ed::IPlugin2*)plugin;
-					plugin2->GetHostIPluginMaxVersion = []() -> int {
-						return 2;
-					};
-					plugin2->ImGuiFileDialogOpen = [](const char* key, const char* title, const char* filter) {
-						ifd::FileDialog::Instance().Save(key, title, filter);
-					};
-					plugin2->ImGuiDirectoryDialogOpen = [](const char* key, const char* title) {
-						ifd::FileDialog::Instance().Open(key, title, "");
-					};
-					plugin2->ImGuiFileDialogIsDone = [](const char* key) -> bool {
-						return ifd::FileDialog::Instance().IsDone(key);
-					};
-					plugin2->ImGuiFileDialogClose = [](const char* key) {
-						ifd::FileDialog::Instance().Close();
-					};
-					plugin2->ImGuiFileDialogGetResult = []() -> bool {
-						return ifd::FileDialog::Instance().HasResult();
-					};
-					plugin2->ImGuiFileDialogGetPath = [](char* outPath) {
-						std::string res = ifd::FileDialog::Instance().GetResult().u8string();
-						strcpy(outPath, res.c_str());
-					};
-					plugin2->DebuggerImmediate = [](void* Debugger, const char* expr) -> const char* {
-						static std::string buffer;
-						spvm_result_t resType = nullptr;
-						spvm_result_t res = ((ed::DebugInformation*)Debugger)->Immediate(expr, resType);
-
-						if (res != nullptr) {
-							std::stringstream ss;
-							((ed::DebugInformation*)Debugger)->GetVariableValueAsString(ss, ((ed::DebugInformation*)Debugger)->GetVMImmediate(), resType, res->members, res->member_count, "");
-							buffer = ss.str();
-						} else
-							buffer = "ERROR";
-
-						return buffer.c_str();
-					};
-				}
-
-#ifdef SHADERED_DESKTOP 
-				bool initResult = plugin->Init(false, SHADERED_VERSION);
-#else
-				bool initResult = plugin->Init(true, SHADERED_VERSION);
-#endif
-				plugin->InitUI(ImGui::GetCurrentContext());
 				
-				if (initResult)
-					ed::Logger::Get().Log("Plugin \"" + pname + "\" successfully initialized.");
-				else
-					ed::Logger::Get().Log("Failed to initialize plugin \"" + pname + "\".");
-
-				m_plugins.push_back(plugin);
-				m_proc.push_back(procDLL);
-				m_names.push_back(pname);
-				m_apiVersion.push_back(apiVer);
-				m_pluginVersion.push_back(pluginVer);
-
-				bool isIn = false;
-				for (const auto& line : iniLines) {
-					if (isIn) {
-						size_t sepLoc = line.find('=');
-						if (sepLoc != std::string::npos) {
-							std::string key = line.substr(0, sepLoc);
-							std::string val = line.substr(sepLoc + 1);
-
-							plugin->Options_Parse(key.c_str(), val.c_str());
-						}
-					}
-
-					if (line.find("[" + pname + "]") == 0)
-						isIn = true;
-					else if (line.size()>0 && line[0] == '[')
-						isIn = false;
-				}
-
-				int customLangCount = plugin->CustomLanguage_GetCount();
-				for (int i = 0; i < customLangCount; i++) {
-					std::string langExt(plugin->CustomLanguage_GetDefaultExtension(i));
-					bool isUsedSomewhere = false;
-
-					for (const std::string& ext : Settings::Instance().General.HLSLExtensions) {
-						if (ext == langExt) {
-							isUsedSomewhere = true;
-							break;
-						}
-					}
-					for (const std::string& ext : Settings::Instance().General.VulkanGLSLExtensions) {
-						if (ext == langExt) {
-							isUsedSomewhere = true;
-							break;
-						}
-					}
-					for (const auto& pair : Settings::Instance().General.PluginShaderExtensions) {
-						for (const std::string& ext : pair.second) {
-							if (ext == langExt) {
-								isUsedSomewhere = true;
-								break;
-							}
-						}
-					}
-
-					if (!isUsedSomewhere) {
-						std::vector<std::string>& myExts = Settings::Instance().General.PluginShaderExtensions[plugin->CustomLanguage_GetName(i)];
-						if (myExts.size() == 0) myExts.push_back(langExt);
-					}
-				}
+				// register plugin into the manager
+				RegisterPlugin(plugin, pname, apiVer, pluginVer, procDLL);
 			}
 		}
 
@@ -1023,7 +196,7 @@ namespace ed {
 
 		std::ofstream ini(settingsFileLoc);
 
-		for (int i = 0; i < m_plugins.size(); i++) {
+		for (int i = m_plugins.size() - 1; i >= 0; i--) {
 			Logger::Get().Log("Destroying \"" + m_names[i] + "\" plugin.");
 
 			int optc = m_plugins[i]->Options_GetCount();
@@ -1089,6 +262,855 @@ namespace ed {
 		}
 
 		return inpLayout;
+	}
+
+	void PluginManager::RegisterPlugin(IPlugin1* plugin, const std::string pname, int apiVer, int pluginVer, void* procDLL)
+	{
+		// set up pointers to app functions
+		plugin->ObjectManager = (void*)&m_data->Objects;
+		plugin->PipelineManager = (void*)&m_data->Pipeline;
+		plugin->Renderer = (void*)&m_data->Renderer;
+		plugin->Messages = (void*)&m_data->Messages;
+		plugin->Project = (void*)&m_data->Parser;
+		plugin->Debugger = (void*)&m_data->Debugger;
+		plugin->UI = (void*)m_ui;
+		plugin->Plugins = (void*)this;
+
+		plugin->AddObject = [](void* objectManager, const char* name, const char* type, void* data, unsigned int id, void* owner) {
+			ObjectManager* objm = (ObjectManager*)objectManager;
+			objm->CreatePluginItem(name, type, data, id, (IPlugin1*)owner);
+		};
+		plugin->AddCustomPipelineItem = [](void* pipeManager, void* parentPtr, const char* name, const char* type, void* data, void* owner) -> bool {
+			PipelineManager* pipe = (PipelineManager*)pipeManager;
+			PipelineItem* parent = (PipelineItem*)parentPtr;
+			char* parentName = nullptr;
+
+			if (parent != nullptr)
+				parentName = parent->Name;
+
+			return pipe->AddPluginItem(parentName, name, type, data, (IPlugin1*)owner);
+		};
+		plugin->AddMessage = [](void* messages, plugin::MessageType mtype, const char* group, const char* txt, int ln) {
+			MessageStack* msgs = (MessageStack*)messages;
+			std::string groupStr = "";
+			if (group != nullptr)
+				groupStr = std::string(group);
+			msgs->Add((MessageStack::Type)mtype, groupStr, txt, ln);
+		};
+		plugin->CreateRenderTexture = [](void* objects, const char* name) -> bool {
+			ObjectManager* objs = (ObjectManager*)objects;
+			return objs->CreateRenderTexture(name);
+		};
+		plugin->CreateImage = [](void* objects, const char* name, int width, int height) -> bool {
+			ObjectManager* objs = (ObjectManager*)objects;
+			return objs->CreateImage(name, glm::ivec2(width, height));
+		};
+		plugin->ResizeRenderTexture = [](void* objects, const char* name, int width, int height) {
+			ObjectManager* objs = (ObjectManager*)objects;
+			objs->ResizeRenderTexture(objs->Get(name), glm::ivec2(width, height));
+		};
+		plugin->ResizeImage = [](void* objects, const char* name, int width, int height) {
+			ObjectManager* objs = (ObjectManager*)objects;
+			objs->ResizeImage(objs->Get(name), glm::ivec2(width, height));
+		};
+		plugin->ExistsObject = [](void* objects, const char* name) -> bool {
+			ObjectManager* objs = (ObjectManager*)objects;
+			return objs->Exists(name);
+		};
+		plugin->RemoveGlobalObject = [](void* objects, const char* name) {
+			ObjectManager* objs = (ObjectManager*)objects;
+			objs->Remove(name);
+		};
+		plugin->GetProjectPath = [](void* project, const char* filename, char* out) {
+			ProjectParser* proj = (ProjectParser*)project;
+			std::string path = proj->GetProjectPath(filename);
+			strcpy(out, path.c_str());
+		};
+		plugin->GetRelativePath = [](void* project, const char* filename, char* out) {
+			ProjectParser* proj = (ProjectParser*)project;
+			std::string path = proj->GetRelativePath(filename);
+			strcpy(out, path.c_str());
+		};
+		plugin->GetProjectFilename = [](void* project, char* out) {
+			ProjectParser* proj = (ProjectParser*)project;
+			std::string path = proj->GetOpenedFile();
+			strcpy(out, path.c_str());
+		};
+		plugin->GetProjectDirectory = [](void* project) -> const char* {
+			ProjectParser* proj = (ProjectParser*)project;
+			return proj->GetProjectDirectory().c_str();
+		};
+		plugin->IsProjectModified = [](void* project) -> bool {
+			ProjectParser* proj = (ProjectParser*)project;
+			return proj->IsProjectModified();
+		};
+		plugin->ModifyProject = [](void* project) {
+			ProjectParser* proj = (ProjectParser*)project;
+			proj->ModifyProject();
+		};
+		plugin->OpenProject = [](void* uiData, const char* filename) {
+			GUIManager* ui = (GUIManager*)uiData;
+			ui->Open(filename);
+		};
+		plugin->SaveProject = [](void* project) {
+			ProjectParser* proj = (ProjectParser*)project;
+			proj->Save();
+		};
+		plugin->SaveAsProject = [](void* project, const char* filename, bool copyFiles) {
+			ProjectParser* proj = (ProjectParser*)project;
+			proj->SaveAs(filename, copyFiles);
+		};
+		plugin->IsPaused = [](void* renderer) -> bool {
+			RenderEngine* rend = (RenderEngine*)renderer;
+			return rend->IsPaused();
+		};
+		plugin->Pause = [](void* renderer, bool state) {
+			RenderEngine* rend = (RenderEngine*)renderer;
+			rend->Pause(state);
+		};
+		plugin->GetWindowColorTexture = [](void* renderer) -> unsigned int {
+			RenderEngine* rend = (RenderEngine*)renderer;
+			return rend->GetTexture();
+		};
+		plugin->GetWindowDepthTexture = [](void* renderer) -> unsigned int {
+			RenderEngine* rend = (RenderEngine*)renderer;
+			return rend->GetDepthTexture();
+		};
+		plugin->GetLastRenderSize = [](void* renderer, int& w, int& h) {
+			RenderEngine* rend = (RenderEngine*)renderer;
+			glm::ivec2 sz = rend->GetLastRenderSize();
+			w = sz.x;
+			h = sz.y;
+		};
+		plugin->Render = [](void* renderer, int w, int h) {
+			RenderEngine* rend = (RenderEngine*)renderer;
+			rend->Render(w, h);
+		};
+		plugin->ExistsPipelineItem = [](void* pipeline, const char* name) -> bool {
+			PipelineManager* pipe = (PipelineManager*)pipeline;
+			return pipe->Has(name);
+		};
+		plugin->GetPipelineItem = [](void* pipeline, const char* name) -> void* {
+			PipelineManager* pipe = (PipelineManager*)pipeline;
+			return (void*)pipe->Get(name);
+		};
+		plugin->BindShaderPassVariables = [](void* shaderpass, void* item) {
+			pipe::ShaderPass* data = (pipe::ShaderPass*)shaderpass;
+			data->Variables.Bind(item);
+		};
+		plugin->GetViewMatrix = [](float* out) {
+			glm::mat4 viewm = SystemVariableManager::Instance().GetViewMatrix();
+			memcpy(out, glm::value_ptr(viewm), sizeof(float) * 4 * 4);
+		};
+		plugin->GetProjectionMatrix = [](float* out) {
+			glm::mat4 projm = SystemVariableManager::Instance().GetProjectionMatrix();
+			memcpy(out, glm::value_ptr(projm), sizeof(float) * 4 * 4);
+		};
+		plugin->GetOrthographicMatrix = [](float* out) {
+			glm::mat4 orthom = SystemVariableManager::Instance().GetOrthographicMatrix();
+			memcpy(out, glm::value_ptr(orthom), sizeof(float) * 4 * 4);
+		};
+		plugin->GetViewportSize = [](float& w, float& h) {
+			glm::vec2 viewsize = SystemVariableManager::Instance().GetViewportSize();
+			w = viewsize.x;
+			h = viewsize.y;
+		};
+		plugin->AdvanceTimer = [](float t) {
+			SystemVariableManager::Instance().AdvanceTimer(t);
+		};
+		plugin->GetMousePosition = [](float& x, float& y) {
+			glm::vec2 mpos = SystemVariableManager::Instance().GetMousePosition();
+			x = mpos.x;
+			y = mpos.y;
+		};
+		plugin->GetFrameIndex = []() -> int {
+			return SystemVariableManager::Instance().GetFrameIndex();
+		};
+		plugin->GetTime = []() -> float {
+			return SystemVariableManager::Instance().GetTime();
+		};
+		plugin->SetTime = [](float time) {
+			float curTime = SystemVariableManager::Instance().GetTime();
+			SystemVariableManager::Instance().AdvanceTimer(time - curTime);
+		};
+		plugin->SetGeometryTransform = [](void* item, float scale[3], float rota[3], float pos[3]) {
+			SystemVariableManager::Instance().SetGeometryTransform((PipelineItem*)item, glm::make_vec3(scale), glm::make_vec3(rota), glm::make_vec3(pos));
+		};
+		plugin->SetMousePosition = [](float x, float y) {
+			SystemVariableManager::Instance().SetMousePosition(x, y);
+		};
+		plugin->SetKeysWASD = [](bool w, bool a, bool s, bool d) {
+			SystemVariableManager::Instance().SetKeysWASD(w, a, s, d);
+		};
+		plugin->SetFrameIndex = [](int findex) {
+			SystemVariableManager::Instance().SetFrameIndex(findex);
+		};
+		plugin->GetDPI = []() -> float {
+			return Settings::Instance().DPIScale;
+		};
+		plugin->FileExists = [](void* project, const char* filename) -> bool {
+			ProjectParser* proj = (ProjectParser*)project;
+			return proj->FileExists(filename);
+		};
+		plugin->ClearMessageGroup = [](void* project, const char* group) {
+			MessageStack* msgs = (MessageStack*)project;
+			msgs->ClearGroup(group);
+		};
+		plugin->Log = [](const char* msg, bool error, const char* file, int line) {
+			printf("%s\n", msg);
+			//ed::Logger::Get().Log(msg, error, file, line);
+		};
+		plugin->GetObjectCount = [](void* objects) -> int {
+			ObjectManager* obj = (ObjectManager*)objects;
+			return obj->GetObjects().size();
+		};
+		plugin->GetObjectName = [](void* objects, int index) -> const char* {
+			ObjectManager* obj = (ObjectManager*)objects;
+			return obj->GetObjects()[index]->Name.c_str();
+		};
+		plugin->IsTexture = [](void* objects, const char* name) -> bool {
+			ObjectManager* obj = (ObjectManager*)objects;
+
+			return obj->Get(name)->Type == ObjectType::Texture;
+		};
+		plugin->GetTexture = [](void* objects, const char* name) -> unsigned int {
+			ObjectManager* obj = (ObjectManager*)objects;
+			return obj->Get(name)->Texture;
+		};
+		plugin->GetFlippedTexture = [](void* objects, const char* name) -> unsigned int {
+			ObjectManager* obj = (ObjectManager*)objects;
+			return obj->Get(name)->FlippedTexture;
+		};
+		plugin->GetTextureSize = [](void* objects, const char* name, int& w, int& h) {
+			ObjectManager* obj = (ObjectManager*)objects;
+			glm::ivec2 tsize = obj->Get(name)->TextureSize;
+			w = tsize.x;
+			h = tsize.y;
+		};
+		plugin->BindDefaultState = []() {
+			DefaultState::Bind();
+		};
+		plugin->OpenInCodeEditor = [](void* ui, void* item, const char* filename, int id) {
+			CodeEditorUI* editor = (CodeEditorUI*)((GUIManager*)ui)->Get(ViewID::Code);
+			editor->OpenPluginCode((PipelineItem*)item, filename, id);
+		};
+		plugin->GetPipelineItemCount = [](void* pipeline) -> int {
+			PipelineManager* pipe = (PipelineManager*)pipeline;
+			return pipe->GetList().size();
+		};
+		plugin->GetPipelineItemType = [](void* item) -> plugin::PipelineItemType {
+			return (plugin::PipelineItemType)((PipelineItem*)item)->Type;
+		};
+		plugin->GetPipelineItemByIndex = [](void* pipeline, int index) -> void* {
+			PipelineManager* pipe = (PipelineManager*)pipeline;
+			return (void*)pipe->GetList()[index];
+		};
+		plugin->DEPRECATED_GetOpenDirectoryDialog = [](char* out) -> bool {
+			return false;
+		};
+		plugin->DEPRECATED_GetOpenFileDialog = [](char* out, const char* files) -> bool {
+			return false;
+		};
+		plugin->DEPRECATED_GetSaveFileDialog = [](char* out, const char* files) -> bool {
+			return false;
+		};
+		plugin->GetIncludePathCount = []() -> int {
+			return Settings::Instance().Project.IncludePaths.size();
+		};
+		plugin->GetIncludePath = [](void* project, int index) -> const char* {
+			return Settings::Instance().Project.IncludePaths[index].c_str();
+		};
+		plugin->GetMessagesCurrentItem = [](void* messages) -> const char* {
+			return ((ed::MessageStack*)messages)->CurrentItem.c_str();
+		};
+		plugin->OnEditorContentChange = nullptr; // will be set by CodeEditorUI
+		plugin->GetPipelineItemSPIRV = [](void* item, plugin::ShaderStage stage, int* len) -> unsigned int* {
+			PipelineItem* pItem = (PipelineItem*)item;
+			if (pItem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* data = (pipe::ShaderPass*)pItem->Data;
+
+				if (stage == plugin::ShaderStage::Pixel) {
+					*len = data->PSSPV.size();
+					return data->PSSPV.data();
+				} else if (stage == plugin::ShaderStage::Vertex) {
+					*len = data->VSSPV.size();
+					return data->VSSPV.data();
+				} else if (stage == plugin::ShaderStage::Geometry) {
+					*len = data->GSSPV.size();
+					return data->GSSPV.data();
+				} else if (stage == plugin::ShaderStage::TessellationControl) {
+					*len = data->TCSSPV.size();
+					return data->TCSSPV.data();
+				} else if (stage == plugin::ShaderStage::TessellationEvaluation) {
+					*len = data->TESSPV.size();
+					return data->TESSPV.data();
+				}
+			} else if (pItem->Type == PipelineItem::ItemType::ComputePass) {
+				pipe::ComputePass* data = (pipe::ComputePass*)pItem->Data;
+
+				*len = data->SPV.size();
+				return data->SPV.data();
+			}
+
+			*len = 0;
+			return nullptr;
+		};
+		plugin->RegisterShortcut = [](void* plugin, const char* name) {
+			KeyboardShortcuts::Instance().RegisterPluginShortcut((IPlugin1*)plugin, std::string(name));
+		};
+		plugin->GetSettingsBoolean = [](const char* name) -> bool {
+			const Settings& seti = Settings::Instance();
+
+			std::string lwr(name);
+			std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
+
+			/* GENERAL */
+			if (lwr == "vsync") return seti.General.VSync;
+			if (lwr == "autoopenerrorwindow") return seti.General.AutoOpenErrorWindow;
+			if (lwr == "toolbar") return seti.General.Toolbar;
+			if (lwr == "recovery") return seti.General.Recovery;
+			if (lwr == "checkupdates") return seti.General.CheckUpdates;
+			if (lwr == "recompileonfilechange") return seti.General.RecompileOnFileChange;
+			if (lwr == "autorecompile") return seti.General.AutoRecompile;
+			if (lwr == "autouniforms") return seti.General.AutoUniforms;
+			if (lwr == "autouniformspin") return seti.General.AutoUniformsPin;
+			if (lwr == "autouniformsfunction") return seti.General.AutoUniformsFunction;
+			if (lwr == "autouniformsdelete") return seti.General.AutoUniformsDelete;
+			if (lwr == "reopenshaders") return seti.General.ReopenShaders;
+			if (lwr == "useexternaleditor") return seti.General.UseExternalEditor;
+			if (lwr == "openshadersondblclk") return seti.General.OpenShadersOnDblClk;
+			if (lwr == "itempropsondblclk") return seti.General.ItemPropsOnDblCLk;
+			if (lwr == "selectitemondblclk") return seti.General.SelectItemOnDblClk;
+			if (lwr == "log") return seti.General.Log;
+			if (lwr == "streamlogs") return seti.General.StreamLogs;
+			if (lwr == "pipelogstoterminal") return seti.General.PipeLogsToTerminal;
+			if (lwr == "autoscale") return seti.General.AutoScale;
+			if (lwr == "tips") return seti.General.Tips;
+
+			/* EDITOR */
+			if (lwr == "smartpredictions") return seti.Editor.SmartPredictions;
+			if (lwr == "activesmartpredictions") return seti.Editor.ActiveSmartPredictions;
+			if (lwr == "showwhitespace") return seti.Editor.ShowWhitespace;
+			if (lwr == "highlightcurrentline") return seti.Editor.HiglightCurrentLine;
+			if (lwr == "linenumbers") return seti.Editor.LineNumbers;
+			if (lwr == "statusbar") return seti.Editor.StatusBar;
+			if (lwr == "horizontalscroll") return seti.Editor.HorizontalScroll;
+			if (lwr == "autobracecompletion") return seti.Editor.AutoBraceCompletion;
+			if (lwr == "smartindent") return seti.Editor.SmartIndent;
+			if (lwr == "autoindentonpaste") return seti.Editor.AutoIndentOnPaste;
+			if (lwr == "insertspaces") return seti.Editor.InsertSpaces;
+			if (lwr == "functiontooltips") return seti.Editor.FunctionTooltips;
+			if (lwr == "syntaxhighlighting") return seti.Editor.SyntaxHighlighting;
+
+			/* DEBUG */
+			if (lwr == "showvaluesonhover") return seti.Debug.ShowValuesOnHover;
+			if (lwr == "autofetch") return seti.Debug.AutoFetch;
+			if (lwr == "primitiveoutline") return seti.Debug.PrimitiveOutline;
+			if (lwr == "pixeloutline") return seti.Debug.PixelOutline;
+
+			/* PREVIEW */
+			if (lwr == "pausedonstartup") return seti.Preview.PausedOnStartup;
+			if (lwr == "switchleftrightclick") return seti.Preview.SwitchLeftRightClick;
+			if (lwr == "hidemenuinperformancemode") return seti.Preview.HideMenuInPerformanceMode;
+			if (lwr == "boundingbox") return seti.Preview.BoundingBox;
+			if (lwr == "gizmo") return seti.Preview.Gizmo;
+			if (lwr == "gizmorotationui") return seti.Preview.GizmoRotationUI;
+			if (lwr == "propertypick") return seti.Preview.PropertyPick;
+			if (lwr == "statusbar") return seti.Preview.StatusBar;
+			if (lwr == "applyfpslimittoapp") return seti.Preview.ApplyFPSLimitToApp;
+			if (lwr == "lostfocuslimitfps") return seti.Preview.LostFocusLimitFPS;
+
+			/* PROJECT */
+			if (lwr == "fpcamera") return seti.Project.FPCamera;
+			if (lwr == "usealphachannel") return seti.Project.UseAlphaChannel;
+
+			return false;
+		};
+		plugin->GetSettingsInteger = [](const char* name) -> int {
+			const Settings& seti = Settings::Instance();
+
+			std::string lwr(name);
+			std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
+
+			/* GENERAL */
+			if (lwr == "fontsize") return seti.General.FontSize;
+
+			/* EDITOR */
+			if (lwr == "editorfontsize") return seti.Editor.FontSize;
+			if (lwr == "tabsize") return seti.Editor.TabSize;
+
+			/* PREVIEW */
+			if (lwr == "gizmosnaptranslation") return seti.Preview.GizmoSnapTranslation;
+			if (lwr == "gizmosnapscale") return seti.Preview.GizmoSnapScale;
+			if (lwr == "gizmosnaprotation") return seti.Preview.GizmoSnapRotation;
+			if (lwr == "fpslimit") return seti.Preview.FPSLimit;
+			if (lwr == "msaa") return seti.Preview.MSAA;
+
+			return -1;
+		};
+		plugin->GetSettingsString = [](const char* name) -> const char* {
+			const Settings& seti = Settings::Instance();
+
+			std::string lwr(name);
+			std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
+
+			/* GENERAL */
+			if (lwr == "startuptemplate") return seti.General.StartUpTemplate.c_str();
+			if (lwr == "font") return seti.General.Font;
+
+			/* EDITOR */
+			if (lwr == "editorfont") return seti.Editor.Font;
+
+			return nullptr;
+		};
+		plugin->GetSettingsFloat = [](const char* name) -> float {
+			const Settings& seti = Settings::Instance();
+
+			std::string lwr(name);
+			std::transform(lwr.begin(), lwr.end(), lwr.begin(), tolower);
+
+			if (lwr == "clearcolorr") return seti.Project.ClearColor.r;
+			if (lwr == "clearcolorg") return seti.Project.ClearColor.g;
+			if (lwr == "clearcolorb") return seti.Project.ClearColor.b;
+			if (lwr == "clearcolora") return seti.Project.ClearColor.a;
+
+			return 0.0f;
+		};
+		plugin->GetPreviewUIRect = [](void* ui, float* out) {
+			PreviewUI* preview = (PreviewUI*)(((GUIManager*)ui)->Get(ViewID::Preview));
+			glm::vec2 pos = preview->GetUIRectPosition();
+			glm::vec2 size = preview->GetUIRectSize();
+			out[0] = pos.x;
+			out[1] = pos.y;
+			out[2] = size.x;
+			out[3] = size.y;
+		};
+		plugin->GetPlugin = [](void* pluginManager, const char* name) -> void* {
+			return (void*)((PluginManager*)pluginManager)->GetPlugin(name);
+		};
+		plugin->GetPluginListSize = [](void* pluginManager) -> int {
+			return ((PluginManager*)pluginManager)->Plugins().size();
+		};
+		plugin->GetPluginName = [](void* pluginManager, int index) -> const char* {
+			PluginManager* pl = (PluginManager*)pluginManager;
+			if (index >= pl->Plugins().size() || index <= 0)
+				return nullptr;
+			return pl->GetPluginName(pl->Plugins()[index]).c_str();
+		};
+		plugin->SendPluginMessage = [](void* pluginManager, void* plugin, const char* receiver, char* msg, int msgLen) {
+			PluginManager* pl = (PluginManager*)pluginManager;
+			IPlugin1* receiverPlugin = pl->GetPlugin(receiver);
+
+			if (receiverPlugin)
+				receiverPlugin->HandlePluginMessage(pl->GetPluginName((IPlugin1*)plugin).c_str(), msg, msgLen);
+		};
+		plugin->BroadcastPluginMessage = [](void* pluginManager, void* plugin, char* msg, int msgLen) {
+			PluginManager* pl = (PluginManager*)pluginManager;
+			const char* myName = pl->GetPluginName((IPlugin1*)plugin).c_str();
+			for (auto& p : pl->Plugins())
+				p->HandlePluginMessage(myName, msg, msgLen);
+		};
+		plugin->ToggleFullscreen = [](void* UI) {
+			SDL_Window* wnd = ((GUIManager*)UI)->GetSDLWindow();
+			Uint32 wndFlags = SDL_GetWindowFlags(wnd);
+			bool isFullscreen = wndFlags & SDL_WINDOW_FULLSCREEN_DESKTOP;
+			SDL_SetWindowFullscreen(wnd, (!isFullscreen) * SDL_WINDOW_FULLSCREEN_DESKTOP);
+		};
+		plugin->IsFullscreen = [](void* UI) -> bool {
+			SDL_Window* wnd = ((GUIManager*)UI)->GetSDLWindow();
+			return SDL_GetWindowFlags(wnd) & SDL_WINDOW_FULLSCREEN_DESKTOP;
+		};
+		plugin->TogglePerformanceMode = [](void* UI) {
+			((GUIManager*)UI)->SetPerformanceMode(!((GUIManager*)UI)->IsPerformanceMode());
+		};
+		plugin->IsInPerformanceMode = [](void* UI) -> bool {
+			return ((GUIManager*)UI)->IsPerformanceMode();
+		};
+		plugin->GetPipelineItemName = [](void* item) -> const char* {
+			return ((PipelineItem*)item)->Name;
+		};
+		plugin->GetPipelineItemPluginOwner = [](void* item) -> void* {
+			PipelineItem* pitem = ((PipelineItem*)item);
+			if (pitem->Type == PipelineItem::ItemType::PluginItem)
+				return ((pipe::PluginItemData*)pitem->Data)->Owner;
+			return nullptr;
+		};
+		plugin->GetPipelineItemVariableCount = [](void* item) -> int {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
+				return pass->Variables.GetVariables().size();
+			} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
+				pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
+				return pass->Variables.GetVariables().size();
+			} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
+				pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
+				return pass->Variables.GetVariables().size();
+			}
+
+			return 0;
+		};
+		plugin->GetPipelineItemVariableName = [](void* item, int index) -> const char* {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
+				return pass->Variables.GetVariables()[index]->Name;
+			} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
+				pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
+				return pass->Variables.GetVariables()[index]->Name;
+			} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
+				pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
+				return pass->Variables.GetVariables()[index]->Name;
+			}
+
+			return nullptr;
+		};
+		plugin->GetPipelineItemVariableValue = [](void* item, int index) -> char* {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
+				return pass->Variables.GetVariables()[index]->Data;
+			} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
+				pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
+				return pass->Variables.GetVariables()[index]->Data;
+			} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
+				pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
+				return pass->Variables.GetVariables()[index]->Data;
+			}
+
+			return nullptr;
+		};
+		plugin->GetPipelineItemVariableType = [](void* item, int index) -> plugin::VariableType {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
+				return (plugin::VariableType)pass->Variables.GetVariables()[index]->GetType();
+			} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
+				pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
+				return (plugin::VariableType)pass->Variables.GetVariables()[index]->GetType();
+			} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
+				pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
+				return (plugin::VariableType)pass->Variables.GetVariables()[index]->GetType();
+			}
+
+			return plugin::VariableType::Float1;
+		};
+		plugin->AddPipelineItemVariable = [](void* item, const char* name, plugin::VariableType type) -> bool {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
+				if (pass->Variables.ContainsVariable(name)) return false;
+				pass->Variables.AddCopy(ed::ShaderVariable((ed::ShaderVariable::ValueType)type, name));
+				return true;
+			} else if (pitem->Type == PipelineItem::ItemType::ComputePass) {
+				pipe::ComputePass* pass = (pipe::ComputePass*)pitem->Data;
+				if (pass->Variables.ContainsVariable(name)) return false;
+				pass->Variables.AddCopy(ed::ShaderVariable((ed::ShaderVariable::ValueType)type, name));
+				return true;
+			} else if (pitem->Type == PipelineItem::ItemType::AudioPass) {
+				pipe::AudioPass* pass = (pipe::AudioPass*)pitem->Data;
+				if (pass->Variables.ContainsVariable(name)) return false;
+				pass->Variables.AddCopy(ed::ShaderVariable((ed::ShaderVariable::ValueType)type, name));
+				return true;
+			}
+
+			return false;
+		};
+		plugin->GetPipelineItemChildrenCount = [](void* item) -> int {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
+				return pass->Items.size();
+			} else if (pitem->Type == PipelineItem::ItemType::PluginItem) {
+				pipe::PluginItemData* pass = (pipe::PluginItemData*)pitem->Data;
+				return pass->Items.size();
+			}
+
+			return 0;
+		};
+		plugin->GetPipelineItemChild = [](void* item, int index) -> void* {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::ShaderPass) {
+				pipe::ShaderPass* pass = (pipe::ShaderPass*)pitem->Data;
+				return pass->Items[index];
+			} else if (pitem->Type == PipelineItem::ItemType::PluginItem) {
+				pipe::PluginItemData* pass = (pipe::PluginItemData*)pitem->Data;
+				return pass->Items[index];
+			}
+
+			return nullptr;
+		};
+		plugin->SetPipelineItemPosition = [](void* item, float x, float y, float z) {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::Geometry) {
+				pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
+				item->Position = glm::vec3(x, y, z);
+			} else if (pitem->Type == PipelineItem::ItemType::Model) {
+				pipe::Model* item = (pipe::Model*)pitem->Data;
+				item->Position = glm::vec3(x, y, z);
+			}
+		};
+		plugin->SetPipelineItemRotation = [](void* item, float x, float y, float z) {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::Geometry) {
+				pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
+				item->Rotation = glm::vec3(x, y, z);
+			} else if (pitem->Type == PipelineItem::ItemType::Model) {
+				pipe::Model* item = (pipe::Model*)pitem->Data;
+				item->Rotation = glm::vec3(x, y, z);
+			}
+		};
+		plugin->SetPipelineItemScale = [](void* item, float x, float y, float z) {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::Geometry) {
+				pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
+				item->Scale = glm::vec3(x, y, z);
+			} else if (pitem->Type == PipelineItem::ItemType::Model) {
+				pipe::Model* item = (pipe::Model*)pitem->Data;
+				item->Scale = glm::vec3(x, y, z);
+			}
+		};
+		plugin->GetPipelineItemPosition = [](void* item, float* data) {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::Geometry) {
+				pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
+				data[0] = item->Position.x;
+				data[1] = item->Position.y;
+				data[2] = item->Position.z;
+			} else if (pitem->Type == PipelineItem::ItemType::Model) {
+				pipe::Model* item = (pipe::Model*)pitem->Data;
+				data[0] = item->Position.x;
+				data[1] = item->Position.y;
+				data[2] = item->Position.z;
+			}
+		};
+		plugin->GetPipelineItemRotation = [](void* item, float* data) {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::Geometry) {
+				pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
+				data[0] = item->Rotation.x;
+				data[1] = item->Rotation.y;
+				data[2] = item->Rotation.z;
+			} else if (pitem->Type == PipelineItem::ItemType::Model) {
+				pipe::Model* item = (pipe::Model*)pitem->Data;
+				data[0] = item->Rotation.x;
+				data[1] = item->Rotation.y;
+				data[2] = item->Rotation.z;
+			}
+		};
+		plugin->GetPipelineItemScale = [](void* item, float* data) {
+			PipelineItem* pitem = ((PipelineItem*)item);
+
+			if (pitem->Type == PipelineItem::ItemType::Geometry) {
+				pipe::GeometryItem* item = (pipe::GeometryItem*)pitem->Data;
+				data[0] = item->Scale.x;
+				data[1] = item->Scale.y;
+				data[2] = item->Scale.z;
+			} else if (pitem->Type == PipelineItem::ItemType::Model) {
+				pipe::Model* item = (pipe::Model*)pitem->Data;
+				data[0] = item->Scale.x;
+				data[1] = item->Scale.y;
+				data[2] = item->Scale.z;
+			}
+		};
+		plugin->PushNotification = [](void* UI, void* plugin, int id, const char* text, const char* btn) {
+			((GUIManager*)UI)->AddNotification(
+				id, text, btn, [](int id, IPlugin1* pl) {
+					pl->HandleNotification(id);
+				},
+				(IPlugin1*)plugin);
+		};
+		plugin->DebuggerJump = [](void* Debugger, void* ed, int line) {
+			((ed::DebugInformation*)Debugger)->Jump(line);
+			int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
+			((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
+		};
+		plugin->DebuggerContinue = [](void* Debugger, void* ed) {
+			((ed::DebugInformation*)Debugger)->Continue();
+			int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
+			((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
+		};
+		plugin->DebuggerStep = [](void* Debugger, void* ed) {
+			((ed::DebugInformation*)Debugger)->Step();
+			int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
+			((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
+		};
+		plugin->DebuggerStepInto = [](void* Debugger, void* ed) {
+			((ed::DebugInformation*)Debugger)->StepInto();
+			int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
+			((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
+		};
+		plugin->DebuggerStepOut = [](void* Debugger, void* ed) {
+			((ed::DebugInformation*)Debugger)->StepOut();
+			int curLine = ((ed::DebugInformation*)Debugger)->GetCurrentLine();
+			((TextEditor*)ed)->SetCurrentLineIndicator(curLine);
+		};
+		plugin->DebuggerCheckBreakpoint = [](void* Debugger, void* ed, int line) -> bool {
+			return ((ed::DebugInformation*)Debugger)->CheckBreakpoint(line);
+		};
+		plugin->DebuggerIsDebugging = [](void* Debugger, void* ed) -> bool {
+			return ((ed::DebugInformation*)Debugger)->IsDebugging();
+		};
+		plugin->DebuggerGetCurrentLine = [](void* Debugger) -> int {
+			return ((ed::DebugInformation*)Debugger)->GetCurrentLine();
+		};
+		plugin->IsRenderTexture = [](void* objects, const char* name) -> bool {
+			ObjectManager* obj = (ObjectManager*)objects;
+			ObjectManagerItem* item = obj->Get(name);
+
+			if (item && item->RT != nullptr)
+				return true;
+
+			return false;
+		};
+		plugin->GetRenderTextureSize = [](void* objects, const char* name, int& w, int& h) {
+			ObjectManager* obj = (ObjectManager*)objects;
+			ObjectManagerItem* item = obj->Get(name);
+			glm::ivec2 tsize = obj->GetRenderTextureSize(item);
+			w = tsize.x;
+			h = tsize.y;
+		};
+		plugin->GetDepthTexture = [](void* objects, const char* name) -> unsigned int {
+			ObjectManager* obj = (ObjectManager*)objects;
+			return obj->Get(name)->RT->DepthStencilBuffer;
+		};
+		plugin->ScaleSize = [](float size) -> float {
+			return Settings::Instance().CalculateSize(size);
+		};
+
+		if (plugin->GetVersion() >= 2) {
+			ed::IPlugin2* plugin2 = (ed::IPlugin2*)plugin;
+			plugin2->GetHostIPluginMaxVersion = []() -> int {
+				return 2;
+			};
+			plugin2->ImGuiFileDialogOpen = [](const char* key, const char* title, const char* filter) {
+				ifd::FileDialog::Instance().Save(key, title, filter);
+			};
+			plugin2->ImGuiDirectoryDialogOpen = [](const char* key, const char* title) {
+				ifd::FileDialog::Instance().Open(key, title, "");
+			};
+			plugin2->ImGuiFileDialogIsDone = [](const char* key) -> bool {
+				return ifd::FileDialog::Instance().IsDone(key);
+			};
+			plugin2->ImGuiFileDialogClose = [](const char* key) {
+				ifd::FileDialog::Instance().Close();
+			};
+			plugin2->ImGuiFileDialogGetResult = []() -> bool {
+				return ifd::FileDialog::Instance().HasResult();
+			};
+			plugin2->ImGuiFileDialogGetPath = [](char* outPath) {
+				std::string res = ifd::FileDialog::Instance().GetResult().u8string();
+				strcpy(outPath, res.c_str());
+			};
+			plugin2->DebuggerImmediate = [](void* Debugger, const char* expr) -> const char* {
+				static std::string buffer;
+				spvm_result_t resType = nullptr;
+				spvm_result_t res = ((ed::DebugInformation*)Debugger)->Immediate(expr, resType);
+
+				if (res != nullptr) {
+					std::stringstream ss;
+					((ed::DebugInformation*)Debugger)->GetVariableValueAsString(ss, ((ed::DebugInformation*)Debugger)->GetVMImmediate(), resType, res->members, res->member_count, "");
+					buffer = ss.str();
+				} else
+					buffer = "ERROR";
+
+				return buffer.c_str();
+			};
+		}
+
+		if (plugin->GetVersion() >= 3) {
+			ed::IPlugin3* plugin3 = (ed::IPlugin3*)plugin;
+			plugin3->RegisterPlugin = [](void* pluginManager, void* plugin, const char* pname, int apiVer, int pluginVer, void* procDLL) {
+				PluginManager* pm = (PluginManager*)pluginManager;
+				IPlugin1* p = (IPlugin1*)plugin;
+				pm->RegisterPlugin(p, pname, apiVer, pluginVer, procDLL);
+			};
+		}
+
+#ifdef SHADERED_DESKTOP
+		bool initResult = plugin->Init(false, SHADERED_VERSION);
+#else
+		bool initResult = plugin->Init(true, SHADERED_VERSION);
+#endif
+		plugin->InitUI(ImGui::GetCurrentContext());
+
+		if (initResult)
+			ed::Logger::Get().Log("Plugin \"" + pname + "\" successfully initialized.");
+		else
+			ed::Logger::Get().Log("Failed to initialize plugin \"" + pname + "\".");
+
+		m_plugins.push_back(plugin);
+		m_proc.push_back(procDLL);
+		m_names.push_back(pname);
+		m_apiVersion.push_back(apiVer);
+		m_pluginVersion.push_back(pluginVer);
+
+		bool isIn = false;
+		for (const auto& line : m_iniLines) {
+			if (isIn) {
+				size_t sepLoc = line.find('=');
+				if (sepLoc != std::string::npos) {
+					std::string key = line.substr(0, sepLoc);
+					std::string val = line.substr(sepLoc + 1);
+
+					plugin->Options_Parse(key.c_str(), val.c_str());
+				}
+			}
+
+			if (line.find("[" + pname + "]") == 0)
+				isIn = true;
+			else if (line.size() > 0 && line[0] == '[')
+				isIn = false;
+		}
+
+		int customLangCount = plugin->CustomLanguage_GetCount();
+		for (int i = 0; i < customLangCount; i++) {
+			std::string langExt(plugin->CustomLanguage_GetDefaultExtension(i));
+			bool isUsedSomewhere = false;
+
+			for (const std::string& ext : Settings::Instance().General.HLSLExtensions) {
+				if (ext == langExt) {
+					isUsedSomewhere = true;
+					break;
+				}
+			}
+			for (const std::string& ext : Settings::Instance().General.VulkanGLSLExtensions) {
+				if (ext == langExt) {
+					isUsedSomewhere = true;
+					break;
+				}
+			}
+			for (const auto& pair : Settings::Instance().General.PluginShaderExtensions) {
+				for (const std::string& ext : pair.second) {
+					if (ext == langExt) {
+						isUsedSomewhere = true;
+						break;
+					}
+				}
+			}
+
+			if (!isUsedSomewhere) {
+				std::vector<std::string>& myExts = Settings::Instance().General.PluginShaderExtensions[plugin->CustomLanguage_GetName(i)];
+				if (myExts.size() == 0) myExts.push_back(langExt);
+			}
+		}
+
+		if (plugin->GetVersion() >= 3) {
+			ed::IPlugin3* plugin3 = (ed::IPlugin3*)plugin;
+			plugin3->PluginManager_RegisterPlugins();
+		}
 	}
 
 	IPlugin1* PluginManager::GetPlugin(const std::string& plugin)

--- a/src/SHADERed/Objects/PluginManager.h
+++ b/src/SHADERed/Objects/PluginManager.h
@@ -21,6 +21,8 @@ namespace ed {
 		void BeginRender();
 		void EndRender();
 
+		void RegisterPlugin(IPlugin1* plugin, const std::string pname, int apiVer, int pluginVer, void* procDLL = nullptr);
+		
 		IPlugin1* GetPlugin(const std::string& plugin);
 		const std::string& GetPluginName(IPlugin1* plugin);
 		int GetPluginVersion(const std::string& plugin);
@@ -58,5 +60,9 @@ namespace ed {
 
 		
 		std::vector<std::string> m_incompatible;
+
+		InterfaceManager* m_data;
+		GUIManager* m_ui;
+		std::vector<std::string> m_iniLines;
 	};
 }


### PR DESCRIPTION
This PR adds [`IPlugin3`](https://github.com/KevinGliewe/SHADERed/blob/5efeb121dd39f96218ab34d633193167c921c10f/src/SHADERed/Objects/PluginAPI/Plugin.h#L477-L484) witch gives plugins the possibility to register plugins themselves.

This functionality can be used to create runtime-plugins for different languages.

I created an [experimantal .NET 5 runtime plugin](https://github.com/KevinGliewe/SHADERedCLR) based on it.

Since you mentioned in your [Blog Post](https://shadered.org/blog?id=9) you plan to extend the plugin api anyway, i thought it would be a great opportunity to propose this addition as well.

## The major changes

* Addition of the type [`IPlugin3`](https://github.com/KevinGliewe/SHADERed/blob/5efeb121dd39f96218ab34d633193167c921c10f/src/SHADERed/Objects/PluginAPI/Plugin.h#L477-L484)
* Move a lot of the plugin initialisation from `PluginManager::Init` to the new method [`PluginManager::RegisterPlugin`](https://github.com/KevinGliewe/SHADERed/blob/5efeb121dd39f96218ab34d633193167c921c10f/src/SHADERed/Objects/PluginManager.cpp#L267) and [wrap it for `IPlugin3::RegisterPlugin`](https://github.com/KevinGliewe/SHADERed/blob/5efeb121dd39f96218ab34d633193167c921c10f/src/SHADERed/Objects/PluginManager.cpp#L1035-L1039)
* Call the [`IPlugin3::PluginManager_RegisterPlugins`](https://github.com/KevinGliewe/SHADERed/blob/5efeb121dd39f96218ab34d633193167c921c10f/src/SHADERed/Objects/PluginManager.cpp#L1112) method of a plugin after it's initialisation
* [Destroy plugins in reverse order](https://github.com/KevinGliewe/SHADERed/blob/5efeb121dd39f96218ab34d633193167c921c10f/src/SHADERed/Objects/PluginManager.cpp#L199)