### PR TITLE
Update AppStream metadata for SHADERed 1.5.4

### DIFF
--- a/Misc/Linux/org.shadered.SHADERed.appdata.xml
+++ b/Misc/Linux/org.shadered.SHADERed.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2019-2020 dfranx -->
+<!-- Copyright (c) 2019-2021 dfranx -->
 <component type="desktop">
   <id>org.shadered.SHADERed.desktop</id>
   <name>SHADERed</name>
@@ -27,6 +27,12 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.5.4" date="2021-07-10"/>
+    <release version="1.5.3" date="2021-05-20"/>
+    <release version="1.5.2" date="2021-04-25"/>
+    <release version="1.5.1" date="2021-04-04"/>
+    <release version="1.5" date="2021-03-11"/>
+    <release version="1.4.4" date="2021-02-16"/>
     <release version="1.4.3" date="2020-12-24"/>
     <release version="1.4.2" date="2020-11-05"/>
     <release version="1.4.1" date="2020-10-02"/>
@@ -37,7 +43,7 @@
     <release version="1.3.3" date="2020-04-17"/>
     <release version="1.3.2" date="2020-04-03"/>
     <release version="1.3.1" date="2020-03-18"/>
-    <release version="1.3" date="2020-02-25"/> 
+    <release version="1.3" date="2020-02-25"/>
   </releases>
   <update_contact>hugo.locurcio@hugo.pro</update_contact>
 </component>


### PR DESCRIPTION
This is required so that I can update the Flatpak to the latest version.