### PR TITLE
Add support for sampler settings to more types of textures. 

### DIFF
--- a/src/SHADERed/Objects/ObjectManager.cpp
+++ b/src/SHADERed/Objects/ObjectManager.cpp
@@ -232,16 +232,12 @@ namespace ed {
 		glGenTextures(1, &item->Texture);
 		glBindTexture(GL_TEXTURE_2D, item->Texture);
 		glTexImage2D(GL_TEXTURE_2D, 0, rtObj->Format, size.x, size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glBindTexture(GL_TEXTURE_2D, 0);
 
 		// depth texture
 		glGenTextures(1, &rtObj->DepthStencilBuffer);
 		glBindTexture(GL_TEXTURE_2D, rtObj->DepthStencilBuffer);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, size.x, size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glBindTexture(GL_TEXTURE_2D, 0);
 
 		// color texture ms
@@ -254,6 +250,8 @@ namespace ed {
 		glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, rtObj->DepthStencilBufferMS);
 		glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, Settings::Instance().Preview.MSAA, GL_DEPTH24_STENCIL8, size.x, size.y, true);
 		glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, 0);
+
+		UpdateTextureParameters(item);
 
 		return true;
 	}
@@ -298,10 +296,6 @@ namespace ed {
 		// normal texture
 		glGenTextures(1, &item->Texture);
 		glBindTexture(GL_TEXTURE_2D, item->Texture);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, item->Texture_WrapS);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, item->Texture_WrapT);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 		glGenerateMipmap(GL_TEXTURE_2D);
 		glBindTexture(GL_TEXTURE_2D, 0);
@@ -320,15 +314,13 @@ namespace ed {
 
 		glGenTextures(1, &item->FlippedTexture);
 		glBindTexture(GL_TEXTURE_2D, item->FlippedTexture);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, item->Texture_WrapS);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, item->Texture_WrapT);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, flippedData);
 		glGenerateMipmap(GL_TEXTURE_2D);
 		glBindTexture(GL_TEXTURE_2D, 0);
 
 		item->TextureSize = glm::ivec2(width, height);
+
+		UpdateTextureParameters(item);
 
 		free(flippedData);
 
@@ -363,17 +355,14 @@ namespace ed {
 
 		glGenTextures(1, &item->Texture);
 		glBindTexture(GL_TEXTURE_3D, item->Texture);
-		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
-		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
-		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, item->Texture_WrapS);
-		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, item->Texture_WrapT);
-		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, item->Texture_WrapR);
 		glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, ddsImage->header.width, ddsImage->header.height, ddsImage->header.depth, 0, GL_RGBA, GL_UNSIGNED_BYTE, ddsImage->pixels);
 		glGenerateMipmap(GL_TEXTURE_3D);
 		glBindTexture(GL_TEXTURE_3D, 0);
 
 		item->TextureSize = glm::ivec2(ddsImage->header.width, ddsImage->header.height);
 		item->Depth = ddsImage->header.depth;
+
+		UpdateTextureParameters(item);
 
 		dds_image_free(ddsImage);
 
@@ -398,11 +387,7 @@ namespace ed {
 		int width, height;
 
 		// properties
-		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+		UpdateTextureParameters(item);
 
 		// left face
 		loadCubemapFace(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, m_parser->GetProjectPath(left), width, height);
@@ -517,8 +502,10 @@ namespace ed {
 
 		glGenTextures(1, &item->Texture);
 		glBindTexture(GL_TEXTURE_2D, item->Texture);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, item->Texture_WrapS);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, item->Texture_WrapT);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size.x, size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 		glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -548,8 +535,11 @@ namespace ed {
 
 		glGenTextures(1, &item->Texture);
 		glBindTexture(GL_TEXTURE_3D, item->Texture);
-		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
+		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
+		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, item->Texture_WrapS);
+		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, item->Texture_WrapT);
+		glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, item->Texture_WrapR);
 		glTexImage3D(GL_TEXTURE_3D, 0, iObj->Format, size.x, size.y, size.z, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 		glBindTexture(GL_TEXTURE_3D, 0);
 
@@ -1259,12 +1249,10 @@ namespace ed {
 			item->Texture_VFlipped = !item->Texture_VFlipped;
 		}
 	}
-	void ObjectManager::UpdateTextureParameters(const std::string& name)
+	void ObjectManager::UpdateTextureParameters(ObjectManagerItem* item)
 	{
-		ObjectManagerItem* item = Get(name);
-
 		if (item != nullptr) {
-			if (item->Type == ed::ObjectType::Texture) {
+			if (item->Type == ed::ObjectType::Texture || item->Type == ed::ObjectType::Image || item->Type == ed::ObjectType::RenderTexture) {
 				glBindTexture(GL_TEXTURE_2D, item->Texture);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
@@ -1279,15 +1267,23 @@ namespace ed {
 
 				glBindTexture(GL_TEXTURE_2D, 0);
 			}
-
-			else if (item->Type == ed::ObjectType::Texture3D) {
+ 			else if (item->Type == ed::ObjectType::Texture3D || item->Type == ed::ObjectType::Image3D) {
 				glBindTexture(GL_TEXTURE_3D, item->Texture);
 				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
 				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
 				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, item->Texture_WrapS);
 				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, item->Texture_WrapT);
 				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, item->Texture_WrapR);
+
 				glBindTexture(GL_TEXTURE_3D, 0);
+			} else if (item->Type == ed::ObjectType::CubeMap) {
+				glBindTexture(GL_TEXTURE_CUBE_MAP, item->Texture);
+				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, item->Texture_MinFilter);
+				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, item->Texture_MagFilter);
+				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, item->Texture_WrapS);
+				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, item->Texture_WrapT);
+
+				glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
 			}
 		}
 	}

--- a/src/SHADERed/Objects/ObjectManager.h
+++ b/src/SHADERed/Objects/ObjectManager.h
@@ -67,7 +67,7 @@ namespace ed {
 		std::vector<ed::ShaderVariable::ValueType> ParseBufferFormat(const std::string& str);
 
 		void FlipTexture(const std::string& name);
-		void UpdateTextureParameters(const std::string& name);
+		void UpdateTextureParameters(ObjectManagerItem* item);
 
 		void Bind(ObjectManagerItem* item, PipelineItem* pass);
 		void Unbind(ObjectManagerItem* item, PipelineItem* pass);

--- a/src/SHADERed/Objects/ProjectParser.cpp
+++ b/src/SHADERed/Objects/ProjectParser.cpp
@@ -1120,7 +1120,7 @@ namespace ed {
 				}
 		}
 	
-		m_objects->UpdateTextureParameters(item);
+		m_objects->UpdateTextureParameters(itemData);
 	}
 
 	void ProjectParser::m_parseVariableValue(pugi::xml_node& node, ShaderVariable* var)

--- a/src/SHADERed/Objects/ProjectParser.cpp
+++ b/src/SHADERed/Objects/ProjectParser.cpp
@@ -624,6 +624,10 @@ namespace ed {
 					if (rtObj->ClearColor.g != 0) textureNode.append_attribute("g").set_value(rtObj->ClearColor.g);
 					if (rtObj->ClearColor.b != 0) textureNode.append_attribute("b").set_value(rtObj->ClearColor.b);
 					if (rtObj->ClearColor.a != 0) textureNode.append_attribute("a").set_value(rtObj->ClearColor.a);
+					textureNode.append_attribute("min_filter").set_value(ed::gl::String::TextureMinFilter(item->Texture_MinFilter));
+					textureNode.append_attribute("mag_filter").set_value(ed::gl::String::TextureMagFilter(item->Texture_MagFilter));
+					textureNode.append_attribute("wrap_s").set_value(ed::gl::String::TextureWrap(item->Texture_WrapS));
+					textureNode.append_attribute("wrap_t").set_value(ed::gl::String::TextureWrap(item->Texture_WrapT));
 				}
 
 				if (isCube) {
@@ -637,6 +641,8 @@ namespace ed {
 					textureNode.append_attribute("bottom").set_value(GetTexturePath(texmaps[3], oldProjectPath).c_str());
 					textureNode.append_attribute("right").set_value(GetTexturePath(texmaps[4], oldProjectPath).c_str());
 					textureNode.append_attribute("back").set_value(GetTexturePath(texmaps[5], oldProjectPath).c_str());
+					textureNode.append_attribute("min_filter").set_value(ed::gl::String::TextureMinFilter(item->Texture_MinFilter));
+					textureNode.append_attribute("mag_filter").set_value(ed::gl::String::TextureMagFilter(item->Texture_MagFilter));
 				}
 
 				if ((isTexture && !isKeyboardTexture) || isTexture3D) {
@@ -664,6 +670,10 @@ namespace ed {
 					textureNode.append_attribute("width").set_value(iobj->Size.x);
 					textureNode.append_attribute("height").set_value(iobj->Size.y);
 					textureNode.append_attribute("format").set_value(gl::String::Format(iobj->Format));
+					textureNode.append_attribute("min_filter").set_value(ed::gl::String::TextureMinFilter(item->Texture_MinFilter));
+					textureNode.append_attribute("mag_filter").set_value(ed::gl::String::TextureMagFilter(item->Texture_MagFilter));
+					textureNode.append_attribute("wrap_s").set_value(ed::gl::String::TextureWrap(item->Texture_WrapS));
+					textureNode.append_attribute("wrap_t").set_value(ed::gl::String::TextureWrap(item->Texture_WrapT));
 				}
 				if (isImage3D) {
 					Image3DObject* iobj = item->Image3D;
@@ -672,6 +682,11 @@ namespace ed {
 					textureNode.append_attribute("height").set_value(iobj->Size.y);
 					textureNode.append_attribute("depth").set_value(iobj->Size.z);
 					textureNode.append_attribute("format").set_value(gl::String::Format(iobj->Format));
+					textureNode.append_attribute("min_filter").set_value(ed::gl::String::TextureMinFilter(item->Texture_MinFilter));
+					textureNode.append_attribute("mag_filter").set_value(ed::gl::String::TextureMagFilter(item->Texture_MagFilter));
+					textureNode.append_attribute("wrap_s").set_value(ed::gl::String::TextureWrap(item->Texture_WrapS));
+					textureNode.append_attribute("wrap_t").set_value(ed::gl::String::TextureWrap(item->Texture_WrapT));
+					textureNode.append_attribute("wrap_r").set_value(ed::gl::String::TextureWrap(item->Texture_WrapR));
 				}
 
 				PluginObject* pluginObj = item->Plugin;
@@ -1051,6 +1066,61 @@ namespace ed {
 	{
 		m_file = "";
 		m_projectPath = std::filesystem::current_path().string();
+	}
+
+	void ProjectParser::m_parseTextureParameters(pugi::xml_node& objectNode, ObjectManagerItem* itemData)
+	{
+		// min filter
+		if (!objectNode.attribute("min_filter").empty()) {
+			auto filterName = objectNode.attribute("min_filter").as_string();
+			for (int i = 0; i < HARRAYSIZE(TEXTURE_MIN_FILTER_VALUES); i++)
+				if (strcmp(filterName, TEXTURE_MIN_FILTER_NAMES[i]) == 0) {
+					itemData->Texture_MinFilter = TEXTURE_MIN_FILTER_VALUES[i];
+					break;
+				}
+		}
+
+		// mag filter
+		if (!objectNode.attribute("mag_filter").empty()) {
+			auto filterName = objectNode.attribute("mag_filter").as_string();
+			for (int i = 0; i < HARRAYSIZE(TEXTURE_MAG_FILTER_VALUES); i++)
+				if (strcmp(filterName, TEXTURE_MAG_FILTER_NAMES[i]) == 0) {
+					itemData->Texture_MagFilter = TEXTURE_MAG_FILTER_VALUES[i];
+					break;
+				}
+		}
+
+		// wrap x
+		if (!objectNode.attribute("wrap_s").empty()) {
+			auto filterName = objectNode.attribute("wrap_s").as_string();
+			for (int i = 0; i < HARRAYSIZE(TEXTURE_WRAP_VALUES); i++)
+				if (strcmp(filterName, TEXTURE_WRAP_NAMES[i]) == 0) {
+					itemData->Texture_WrapS = TEXTURE_WRAP_VALUES[i];
+					break;
+				}
+		}
+
+		// wrap y
+		if (!objectNode.attribute("wrap_t").empty()) {
+			auto filterName = objectNode.attribute("wrap_t").as_string();
+			for (int i = 0; i < HARRAYSIZE(TEXTURE_WRAP_VALUES); i++)
+				if (strcmp(filterName, TEXTURE_WRAP_NAMES[i]) == 0) {
+					itemData->Texture_WrapT = TEXTURE_WRAP_VALUES[i];
+					break;
+				}
+		}
+
+		// wrap z
+		if (!objectNode.attribute("wrap_r").empty()) {
+			auto filterName = objectNode.attribute("wrap_r").as_string();
+			for (int i = 0; i < HARRAYSIZE(TEXTURE_WRAP_VALUES); i++)
+				if (strcmp(filterName, TEXTURE_WRAP_NAMES[i]) == 0) {
+					itemData->Texture_WrapR = TEXTURE_WRAP_VALUES[i];
+					break;
+				}
+		}
+	
+		m_objects->UpdateTextureParameters(item);
 	}
 
 	void ProjectParser::m_parseVariableValue(pugi::xml_node& node, ShaderVariable* var)
@@ -2835,70 +2905,17 @@ namespace ed {
 				}
 
 				// texture properties
-				if (!isCube) {
-					ObjectManagerItem* itemData = m_objects->Get(name);
-					if (itemData != nullptr) {
+				ObjectManagerItem* itemData = m_objects->Get(name);
+				if (itemData != nullptr) {
+					if (!isCube) {
 						// vflip
 						bool vflip = false;
 						if (!objectNode.attribute("vflip").empty())
 							vflip = objectNode.attribute("vflip").as_bool();
 						if (vflip)
 							m_objects->FlipTexture(name);
-
-						// min filter
-						if (!objectNode.attribute("min_filter").empty()) {
-							auto filterName = objectNode.attribute("min_filter").as_string();
-							for (int i = 0; i < HARRAYSIZE(TEXTURE_MIN_FILTER_VALUES); i++)
-								if (strcmp(filterName, TEXTURE_MIN_FILTER_NAMES[i]) == 0) {
-									itemData->Texture_MinFilter = TEXTURE_MIN_FILTER_VALUES[i];
-									break;
-								}
-						}
-
-						// mag filter
-						if (!objectNode.attribute("mag_filter").empty()) {
-							auto filterName = objectNode.attribute("mag_filter").as_string();
-							for (int i = 0; i < HARRAYSIZE(TEXTURE_MAG_FILTER_VALUES); i++)
-								if (strcmp(filterName, TEXTURE_MAG_FILTER_NAMES[i]) == 0) {
-									itemData->Texture_MagFilter = TEXTURE_MAG_FILTER_VALUES[i];
-									break;
-								}
-						}
-
-						// wrap x
-						if (!objectNode.attribute("wrap_s").empty()) {
-							auto filterName = objectNode.attribute("wrap_s").as_string();
-							for (int i = 0; i < HARRAYSIZE(TEXTURE_WRAP_VALUES); i++)
-								if (strcmp(filterName, TEXTURE_WRAP_NAMES[i]) == 0) {
-									itemData->Texture_WrapS = TEXTURE_WRAP_VALUES[i];
-									break;
-								}
-						}
-
-						// wrap y
-						if (!objectNode.attribute("wrap_t").empty()) {
-							auto filterName = objectNode.attribute("wrap_t").as_string();
-							for (int i = 0; i < HARRAYSIZE(TEXTURE_WRAP_VALUES); i++)
-								if (strcmp(filterName, TEXTURE_WRAP_NAMES[i]) == 0) {
-									itemData->Texture_WrapT = TEXTURE_WRAP_VALUES[i];
-									break;
-								}
-						}
-
-						if (is3D) {
-							// wrap z
-							if (!objectNode.attribute("wrap_r").empty()) {
-								auto filterName = objectNode.attribute("wrap_r").as_string();
-								for (int i = 0; i < HARRAYSIZE(TEXTURE_WRAP_VALUES); i++)
-									if (strcmp(filterName, TEXTURE_WRAP_NAMES[i]) == 0) {
-										itemData->Texture_WrapT = TEXTURE_WRAP_VALUES[i];
-										break;
-									}
-							}
-						}
-
-						m_objects->UpdateTextureParameters(name);
 					}
+					m_parseTextureParameters(objectNode, itemData);
 				}
 			} else if (strcmp(objType, "rendertexture") == 0) {
 				const pugi::char_t* objName = objectNode.attribute("name").as_string();
@@ -2977,6 +2994,8 @@ namespace ed {
 						}
 					}
 				}
+
+				m_parseTextureParameters(objectNode, rtData);
 			} else if (strcmp(objType, "image") == 0) {
 				const pugi::char_t* objName = objectNode.attribute("name").as_string();
 
@@ -3035,6 +3054,7 @@ namespace ed {
 						}
 					}
 				}
+				m_parseTextureParameters(objectNode, iobjOwner);
 			} else if (strcmp(objType, "image3d") == 0) {
 				const pugi::char_t* objName = objectNode.attribute("name").as_string();
 
@@ -3091,6 +3111,7 @@ namespace ed {
 						}
 					}
 				}
+				m_parseTextureParameters(objectNode, iobjOwner);
 			} else if (strcmp(objType, "audio") == 0) {
 				pugi::char_t objPath[SHADERED_MAX_PATH];
 				strcpy(objPath, toGenericPath(objectNode.attribute("path").as_string()).c_str());

--- a/src/SHADERed/Objects/ProjectParser.h
+++ b/src/SHADERed/Objects/ProjectParser.h
@@ -20,6 +20,7 @@ namespace ed {
 	class PipelineManager;
 	class RenderEngine;
 	class ObjectManager;
+	class ObjectManagerItem;
 	class PluginManager;
 	class InputLayoutItem;
 	class DebugInformation;
@@ -70,6 +71,7 @@ namespace ed {
 		void m_parseV1(pugi::xml_node& projectNode); // old
 		void m_parseV2(pugi::xml_node& projectNode); // current -> merge blend, rasterizer and depth states into one "render state" ||| remove input layout parsing ||| ignore shader entry property
 
+		void m_parseSampler(pugi::xml_node& node, ObjectManagerItem* itemData);
 		void m_parseVariableValue(pugi::xml_node& node, ShaderVariable* var);
 		void m_exportVariableValue(pugi::xml_node& node, ShaderVariable* vars);
 		void m_exportShaderVariables(pugi::xml_node& node, std::vector<ShaderVariable*>& vars);

--- a/src/SHADERed/Objects/ProjectParser.h
+++ b/src/SHADERed/Objects/ProjectParser.h
@@ -71,7 +71,7 @@ namespace ed {
 		void m_parseV1(pugi::xml_node& projectNode); // old
 		void m_parseV2(pugi::xml_node& projectNode); // current -> merge blend, rasterizer and depth states into one "render state" ||| remove input layout parsing ||| ignore shader entry property
 
-		void m_parseSampler(pugi::xml_node& node, ObjectManagerItem* itemData);
+		void m_parseTextureParameters(pugi::xml_node& node, ObjectManagerItem* itemData);
 		void m_parseVariableValue(pugi::xml_node& node, ShaderVariable* var);
 		void m_exportVariableValue(pugi::xml_node& node, ShaderVariable* vars);
 		void m_exportShaderVariables(pugi::xml_node& node, std::vector<ShaderVariable*>& vars);

--- a/src/SHADERed/UI/ObjectListUI.cpp
+++ b/src/SHADERed/UI/ObjectListUI.cpp
@@ -170,7 +170,13 @@ namespace ed {
 					ImGui::Separator();
 				}
 
-				if (oItem->Type == ObjectType::RenderTexture || oItem->Type == ObjectType::Image || oItem->Type == ObjectType::Texture || oItem->Type == ObjectType::Texture3D || isImg3D || (isPluginOwner && pobj->Owner->Object_HasProperties(pobj->Type))) {
+				if (oItem->Type == ObjectType::RenderTexture || 
+					oItem->Type == ObjectType::CubeMap ||
+					oItem->Type == ObjectType::Image || 
+					oItem->Type == ObjectType::Texture || 
+					oItem->Type == ObjectType::Texture3D || 
+					isImg3D || 
+					(isPluginOwner && pobj->Owner->Object_HasProperties(pobj->Type))) {
 					if (ImGui::Selectable("Properties"))
 						((ed::PropertyUI*)m_ui->Get(ViewID::Properties))->Open(oItem);
 				}

--- a/src/SHADERed/UI/PropertyUI.cpp
+++ b/src/SHADERed/UI/PropertyUI.cpp
@@ -30,6 +30,80 @@ namespace ed {
 	void PropertyUI::OnEvent(const SDL_Event& e)
 	{
 	}
+	void PropertyUI::m_renderSamplerParams(int dimension)
+	{
+		bool paramsUpdated = false;
+
+		ImGui::NextColumn();
+		ImGui::Separator();
+
+		if (ImGui::TreeNode("Sampling"))
+		{
+			ImGui::Separator();
+			/* MIN FILTER */
+			ImGui::Text("MinFilter:");
+			ImGui::NextColumn();
+			ImGui::PushItemWidth(-1);
+			if (UIHelper::CreateTextureMinFilterCombo("##prop_tex_min", m_currentObj->Texture_MinFilter))
+				paramsUpdated = true;
+			ImGui::PopItemWidth();
+			ImGui::NextColumn();
+			ImGui::Separator();
+
+			/* MAG FILTER */
+			ImGui::Text("MagFilter:");
+			ImGui::NextColumn();
+			ImGui::PushItemWidth(-1);
+			if (UIHelper::CreateTextureMagFilterCombo("##prop_tex_mag", m_currentObj->Texture_MagFilter))
+				paramsUpdated = true;
+			ImGui::PopItemWidth();
+			ImGui::NextColumn();
+
+			/* WRAP S */
+			if (dimension >= 1) {
+				ImGui::Separator();
+				ImGui::Text("Wrap S:");
+				ImGui::NextColumn();
+				ImGui::PushItemWidth(-1);
+				if (UIHelper::CreateTextureWrapCombo("##prop_tex_wrap_s", m_currentObj->Texture_WrapS))
+					paramsUpdated = true;
+				ImGui::PopItemWidth();
+				ImGui::NextColumn();
+			}
+
+			/* WRAP T */
+			if (dimension >= 2)
+			{
+				ImGui::Separator();
+				ImGui::Text("Wrap T:");
+				ImGui::NextColumn();
+				ImGui::PushItemWidth(-1);
+				if (UIHelper::CreateTextureWrapCombo("##prop_tex_wrap_t", m_currentObj->Texture_WrapT))
+					paramsUpdated = true;
+				ImGui::PopItemWidth();
+				ImGui::NextColumn();
+			}
+
+			/* WRAP R */
+			if (dimension >= 3) {
+				ImGui::Separator();
+				ImGui::Text("Wrap R:");
+				ImGui::NextColumn();
+				ImGui::PushItemWidth(-1);
+				if (UIHelper::CreateTextureWrapCombo("##prop_tex_wrap_r", m_currentObj->Texture_WrapR))
+					paramsUpdated = true;
+				ImGui::PopItemWidth();
+				ImGui::NextColumn();
+			}
+
+			if (paramsUpdated) {
+				m_data->Objects.UpdateTextureParameters(m_currentObj);
+				m_data->Parser.ModifyProject();
+			}
+			ImGui::TreePop();
+		}
+		ImGui::Separator();
+	}
 	void PropertyUI::Update(float delta)
 	{
 		if (m_current != nullptr || m_currentObj != nullptr) {
@@ -1280,6 +1354,8 @@ namespace ed {
 					m_data->Parser.ModifyProject();
 				ImGui::PopItemWidth();
 
+				m_renderSamplerParams(2);
+
 				if (!m_currentRT->Clear) {
 					ImGui::PopStyleVar();
 					ImGui::PopItemFlag();
@@ -1323,8 +1399,8 @@ namespace ed {
 					ImGui::EndCombo();
 				}
 				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
+
+				m_renderSamplerParams(2);
 
 				/* DATA */
 				ImGui::Text("Data:");
@@ -1380,58 +1456,14 @@ namespace ed {
 				ImGui::Text("VFlip:");
 				ImGui::NextColumn();
 				ImGui::PushItemWidth(-1);
-				bool flipped = m_currentObj->Texture_VFlipped, paramsUpdated = false;
+				bool flipped = m_currentObj->Texture_VFlipped;
 				if (ImGui::Checkbox("##prop_tex_vflip", &flipped)) {
 					m_data->Objects.FlipTexture(m_itemName);
 					m_data->Parser.ModifyProject();
 				}
 				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
 
-				/* MIN FILTER */
-				ImGui::Text("MinFilter:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureMinFilterCombo("##prop_tex_min", m_currentObj->Texture_MinFilter))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
-
-				/* MAG FILTER */
-				ImGui::Text("MagFilter:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureMagFilterCombo("##prop_tex_mag", m_currentObj->Texture_MagFilter))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
-
-				/* WRAP S */
-				ImGui::Text("Wrap S:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureWrapCombo("##prop_tex_wrap_s", m_currentObj->Texture_WrapS))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
-
-				/* WRAP T */
-				ImGui::Text("Wrap T:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureWrapCombo("##prop_tex_wrap_t", m_currentObj->Texture_WrapT))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-
-				if (paramsUpdated) {
-					m_data->Objects.UpdateTextureParameters(m_itemName);
-					m_data->Parser.ModifyProject();
-				}
+				m_renderSamplerParams(2);
 			} 
 			else if (IsImage3D()) {
 				ed::Image3DObject* m_currentImg3D = m_currentObj->Image3D;
@@ -1473,6 +1505,8 @@ namespace ed {
 					ImGui::EndCombo();
 				}
 				ImGui::PopItemWidth();
+
+				m_renderSamplerParams(3);
 			} 
 			else if (IsTexture3D()) {
 				/* texture path */
@@ -1486,63 +1520,24 @@ namespace ed {
 				ImGui::SameLine();
 				if (ImGui::Button("...##pui_texbtn", ImVec2(-1, 0)))
 					ifd::FileDialog::Instance().Open("PropertyTextureDlg", "Select a texture", "DDS file (*.dds){.dds},.*");
-				ImGui::NextColumn();
-				ImGui::Separator();
 
-				/* MIN FILTER */
-				ImGui::Text("MinFilter:");
+				m_renderSamplerParams(3);
+			}
+			else if (IsCubeMap()) {
+				/* texture path */
+				ImGui::Text("Path:");
 				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				bool paramsUpdated = false;
-				if (UIHelper::CreateTextureMinFilterCombo("##prop_tex3d_min", m_currentObj->Texture_MinFilter))
-					paramsUpdated = true;
+				ImGui::PushItemWidth(BUTTON_SPACE_LEFT);
+				ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+				ImGui::InputText("##pui_cube_map_path", const_cast<char*>(m_currentObj->Name.c_str()), SHADERED_MAX_PATH); // not like it's going to be modified, amirite
+				ImGui::PopItemFlag();
 				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
+				ImGui::SameLine();
+				if (ImGui::Button("...##pui_texbtn", ImVec2(-1, 0)))
+					ifd::FileDialog::Instance().Open("PropertyTextureDlg", "Select a texture", "DDS file (*.dds){.dds},.*");
 
-				/* MAG FILTER */
-				ImGui::Text("MagFilter:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureMagFilterCombo("##prop_tex3d_mag", m_currentObj->Texture_MagFilter))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
-
-				/* WRAP S */
-				ImGui::Text("Wrap S:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureWrapCombo("##prop_tex3d_wrap_s", m_currentObj->Texture_WrapS))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-				ImGui::Separator();
-
-				/* WRAP T */
-				ImGui::Text("Wrap T:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureWrapCombo("##prop_tex3d_wrap_t", m_currentObj->Texture_WrapT))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-
-				/* WRAP T */
-				ImGui::Text("Wrap R:");
-				ImGui::NextColumn();
-				ImGui::PushItemWidth(-1);
-				if (UIHelper::CreateTextureWrapCombo("##prop_tex3d_wrap_r", m_currentObj->Texture_WrapR))
-					paramsUpdated = true;
-				ImGui::PopItemWidth();
-				ImGui::NextColumn();
-
-				if (paramsUpdated) {
-					m_data->Objects.UpdateTextureParameters(m_itemName);
-					m_data->Parser.ModifyProject();
-				}
-			} 
+				m_renderSamplerParams(0);
+			}
 			else if (IsPlugin()) {
 				ImGui::Columns(1);
 
@@ -1555,7 +1550,6 @@ namespace ed {
 		} else
 			ImGui::TextWrapped("Right click on an item -> Properties");
 
-		
 		// file dialogs
 		if (ifd::FileDialog::Instance().IsDone("PropertyShaderDlg")) {
 			if (ifd::FileDialog::Instance().HasResult()) {

--- a/src/SHADERed/UI/PropertyUI.h
+++ b/src/SHADERed/UI/PropertyUI.h
@@ -28,12 +28,14 @@ namespace ed {
 		inline bool IsImage() { return m_currentObj != nullptr && m_currentObj->Type == ObjectType::Image; }
 		inline bool IsImage3D() { return m_currentObj != nullptr && m_currentObj->Type == ObjectType::Image3D; }
 		inline bool IsTexture3D() { return m_currentObj != nullptr && m_currentObj->Type == ObjectType::Texture3D; }
+		inline bool IsCubeMap() { return m_currentObj != nullptr && m_currentObj->Type == ObjectType::CubeMap; }
 		inline bool IsPlugin() { return m_currentObj != nullptr && m_currentObj->Type == ObjectType::PluginObject; }
 
 	private:
 		char m_itemName[2048];
 
 		void m_init();
+		void m_renderSamplerParams(int dimension);
 
 		PipelineItem* m_current;
 		ObjectManagerItem* m_currentObj;


### PR DESCRIPTION
In particular, texture(3d), rt, image(3d), and cube maps. This includes min/mag settings and wrap settings as appropriate. Access the settings with the new "Sampler" subtree in the properties list.

Tested round trip load/save operation with Image3D and live updating of sampler settings. Desk checked for other types of objects.

This pipeline uses a compute shader to fill an Image3D with a gradient rgb = xyz. This pixel shader is sampling that texture along u, v, 0.5.
![image](https://user-images.githubusercontent.com/63926737/144733189-bd6caec9-20b4-495a-8743-bb3e98e98c67.png)

And with different sampling
![image](https://user-images.githubusercontent.com/63926737/144733210-01812e14-af01-4b82-b63a-8e49c2058834.png)
