### PR TITLE
Fixed segmentation fault

### DIFF
--- a/src/SHADERed/UI/ObjectPreviewUI.cpp
+++ b/src/SHADERed/UI/ObjectPreviewUI.cpp
@@ -445,7 +445,7 @@ namespace ed {
 								static char pxCoord[32] = { 0 };
 
 								for (int i = 0; i < pixelList.size(); i++) {
-									if (pixelList[i].RenderTexture->Name == item->Name && pixelList[i].Fetched) { // we only care about window's pixel info here
+									if (pixelList[i].RenderTexture && pixelList[i].RenderTexture->Name == item->Name && pixelList[i].Fetched) { // we only care about window's pixel info here
 
 										if (Settings::Instance().Debug.PrimitiveOutline) {
 											ImGui::SetCursorPosX(posX);


### PR DESCRIPTION
Caused by access of null pointer in case ShaderPass
does use Window as Output and not a RenderTexture.