### PR TITLE
Add vcpkg.json, fix for issues #332 and #335

### DIFF
--- a/src/SHADERed/Objects/Debug/ExpressionCompiler.cpp
+++ b/src/SHADERed/Objects/Debug/ExpressionCompiler.cpp
@@ -684,10 +684,7 @@ namespace ed {
 					resType = m_module->type<spvgentwo::vector_t<float, 4>*>();
 				
 				if (resType != nullptr) {
-					spvgentwo::Instruction* tempVar = bb->opVariable(obj->getResultTypeInstr(), spvgentwo::spv::StorageClass::Function);
-					bb->opStore(tempVar, obj);
-					spvgentwo::Instruction* vecPtr = bb->opAccessChain(resType, tempVar, m_visit(a_access->Indices[0]));
-					
+					spvgentwo::Instruction* vecPtr = bb->opAccessChain(resType, obj, m_visit(a_access->Indices[0]));
 					return bb->opLoad(vecPtr);
 				}
 			} else if (obj->getType()->isArray() || obj->getType()->isStruct()) {

--- a/src/SHADERed/Objects/FunctionVariableManager.cpp
+++ b/src/SHADERed/Objects/FunctionVariableManager.cpp
@@ -167,6 +167,23 @@ namespace ed {
 				matrix = glm::perspectiveFov(45.0f, view[0], view[1], z[0], z[1]);
 			} break;
 
+			case FunctionShaderVariable::MatrixPerspectiveVFovLH: {
+				float fov = *LoadFloat(var->Arguments, 0);
+				float* view = LoadFloat(var->Arguments, 1);
+				float* z = LoadFloat(var->Arguments, 3);
+
+				matrix = glm::perspective(fov, view[0] / view[1], z[0], z[1]);
+			} break;
+
+			case FunctionShaderVariable::MatrixPerspectiveHFovLH: {
+				float* view = LoadFloat(var->Arguments, 1);
+				float aspect = view[0] / view[1];
+				float fov = *LoadFloat(var->Arguments, 0) / aspect;
+				float* z = LoadFloat(var->Arguments, 3);
+
+				matrix = glm::perspective(fov, aspect, z[0], z[1]);
+			} break;
+
 			case FunctionShaderVariable::MatrixRotationAxis: {
 				float* axis = LoadFloat(var->Arguments, 0);
 				float angle = *LoadFloat(var->Arguments, 3);
@@ -297,6 +314,14 @@ namespace ed {
 				*LoadFloat(var->Arguments, 2) = 0.1f;
 				*LoadFloat(var->Arguments, 3) = 100.0f;
 				break;
+			case FunctionShaderVariable::MatrixPerspectiveVFovLH:
+			case FunctionShaderVariable::MatrixPerspectiveHFovLH:
+				*LoadFloat(var->Arguments, 0) = glm::half_pi<float>();
+				*LoadFloat(var->Arguments, 1) = 800;
+				*LoadFloat(var->Arguments, 2) = 600;
+				*LoadFloat(var->Arguments, 3) = 0.1f;
+				*LoadFloat(var->Arguments, 4) = 100.0f;
+				break;
 			case FunctionShaderVariable::MatrixRotationAxis:
 				*LoadFloat(var->Arguments, 0) = 1;
 				break;
@@ -324,6 +349,8 @@ namespace ed {
 		case FunctionShaderVariable::MatrixOrthographicLH: return 4;
 		case FunctionShaderVariable::MatrixPerspectiveFovLH: return 4;
 		case FunctionShaderVariable::MatrixPerspectiveLH: return 4;
+		case FunctionShaderVariable::MatrixPerspectiveVFovLH: return 5;
+		case FunctionShaderVariable::MatrixPerspectiveHFovLH: return 5;
 		case FunctionShaderVariable::MatrixRotationAxis: return 4;
 		case FunctionShaderVariable::MatrixRotationNormal: return 4;
 		case FunctionShaderVariable::MatrixRotationRollPitchYaw: return 3;

--- a/src/SHADERed/Objects/Names.cpp
+++ b/src/SHADERed/Objects/Names.cpp
@@ -101,6 +101,8 @@ const char* FUNCTION_NAMES[] = {
 	"MatrixOrthographicLH",
 	"MatrixPerspectiveFovLH",
 	"MatrixPerspectiveLH",
+	"MatrixPerspectiveVFovLH",
+	"MatrixPerspectiveHFovLH",
 	"MatrixRotationAxis",
 	"MatrixRotationNormal",
 	"MatrixRotationRollPitchYaw",

--- a/src/SHADERed/Objects/Names.h
+++ b/src/SHADERed/Objects/Names.h
@@ -5,7 +5,7 @@ extern const char* TOPOLOGY_ITEM_NAMES[11];
 extern const char* SYSTEM_VARIABLE_NAMES[22];
 extern const char* VARIABLE_TYPE_NAMES[15];
 extern const char* VARIABLE_TYPE_NAMES_GLSL[15];
-extern const char* FUNCTION_NAMES[22];
+extern const char* FUNCTION_NAMES[24];
 extern const char* GEOMETRY_NAMES[7];
 extern const char* PIPELINE_ITEM_NAMES[8];
 extern const char* BLEND_NAMES[20];

--- a/src/SHADERed/Objects/ShaderVariable.h
+++ b/src/SHADERed/Objects/ShaderVariable.h
@@ -53,6 +53,8 @@ namespace ed {
 		MatrixOrthographicLH,
 		MatrixPerspectiveFovLH,
 		MatrixPerspectiveLH,
+		MatrixPerspectiveVFovLH,
+		MatrixPerspectiveHFovLH,
 		MatrixRotationAxis,
 		MatrixRotationNormal,
 		MatrixRotationRollPitchYaw,

--- a/src/SHADERed/UI/Tools/VariableValueEdit.cpp
+++ b/src/SHADERed/UI/Tools/VariableValueEdit.cpp
@@ -415,10 +415,10 @@ namespace ed {
 			ImGui::NextColumn();
 
 			ImGui::PushItemWidth(-1);
-			float fov = glm::degrees(*FunctionVariableManager::LoadFloat(m_var->Arguments, 0));
+			float fov = *FunctionVariableManager::LoadFloat(m_var->Arguments, 0);
 			if (ImGui::SliderAngle(("##fovAngle" + std::string(m_var->Name)).c_str(), &fov, 0, 180))
 				ret = true;
-			*FunctionVariableManager::LoadFloat(m_var->Arguments, 0) = glm::radians(fov);
+			*FunctionVariableManager::LoadFloat(m_var->Arguments, 0) = fov;
 			ImGui::NextColumn();
 
 			ImGui::Text("Aspect ratio:");

--- a/src/SHADERed/UI/Tools/VariableValueEdit.cpp
+++ b/src/SHADERed/UI/Tools/VariableValueEdit.cpp
@@ -472,6 +472,43 @@ namespace ed {
 			ImGui::NextColumn();
 		} break;
 
+		case FunctionShaderVariable::MatrixPerspectiveVFovLH: 
+		case FunctionShaderVariable::MatrixPerspectiveHFovLH: {
+			ImGui::Text("FOV:");
+			ImGui::NextColumn();
+
+			ImGui::PushItemWidth(-1);
+			float fov = *FunctionVariableManager::LoadFloat(m_var->Arguments, 0);
+			if (ImGui::SliderAngle(("##fovAngle" + std::string(m_var->Name)).c_str(), &fov, 0, 180))
+				ret = true;
+			*FunctionVariableManager::LoadFloat(m_var->Arguments, 0) = fov;
+			ImGui::NextColumn();
+
+			ImGui::Text("View size:");
+			ImGui::NextColumn();
+
+			ImGui::PushItemWidth(-1);
+			if (ImGui::DragFloat2(("##viewSize" + std::string(m_var->Name)).c_str(), FunctionVariableManager::LoadFloat(m_var->Arguments, 1), 0.01f))
+				ret = true;
+			ImGui::NextColumn();
+
+			ImGui::Text("Near Z:");
+			ImGui::NextColumn();
+
+			ImGui::PushItemWidth(-1);
+			if (ImGui::DragFloat(("##nearZ" + std::string(m_var->Name)).c_str(), FunctionVariableManager::LoadFloat(m_var->Arguments, 3), 0.01f))
+				ret = true;
+			ImGui::NextColumn();
+
+			ImGui::Text("Far Z:");
+			ImGui::NextColumn();
+
+			ImGui::PushItemWidth(-1);
+			if (ImGui::DragFloat(("##farZ" + std::string(m_var->Name)).c_str(), FunctionVariableManager::LoadFloat(m_var->Arguments, 4), 0.01f))
+				ret = true;
+			ImGui::NextColumn();
+		} break;
+
 		case FunctionShaderVariable::MatrixRotationAxis: {
 			ImGui::Text("Axis:");
 			ImGui::NextColumn();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "shadered-project",
+  "version": "1.5.6",
+  "description": "SHADERed project compilation",
+  "dependencies": [
+    "sdl2",
+    "glew",
+    "glm"
+  ]
+}


### PR DESCRIPTION
### Description

This PR addresses a part of issue #332 (the vector part is solved with the commit dfranx/SPIRV-VM@1f653d0b5723e009cd23f631eda0b2af4c3ade00 ) and issue #335.


### Changes

This PR solves the usage of matrix-array-operator. Furthermore this PR adds vcpkg.json to SHADERed to add support for vcpkg in manifest mode. This greatly enhances building SHADERed by your own. Last but not least this also solves issue #335 and fixes the buggy degree conversion in Value Edit UI.